### PR TITLE
fix(ci): publish root package only, not workspaces

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Publish workspace packages
-        run: npm publish --workspaces --access public
+      - name: Publish
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Revert `--workspaces` flag — only root `crowclaw` package is published to npm
- `@crowclaw/*` workspace packages are internal, not on npm registry

## Test plan
- [x] CI should pass
- [ ] Re-run publish workflow after merge to verify npm publish succeeds

Generated with [Claude Code](https://claude.com/claude-code)