### PR TITLE
fix: resolve 3 critical + 3 weak bugs from deep review

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,8 +52,11 @@ export interface ToolExecutionContext {
 /** Env var patterns that should never be exposed to tools. */
 const SENSITIVE_ENV_PATTERNS = [
   /api[_-]?key/i, /secret/i, /token/i, /password/i, /credential/i,
+  /private[_-]?key/i, /signing[_-]?key/i, /encryption[_-]?key/i,
   /^OPENAI_/, /^ANTHROPIC_/, /^OPENROUTER_/, /^CROWCLAW_DASHBOARD_TOKEN$/,
-  /^AWS_SECRET/, /^GH_TOKEN$/, /^GITHUB_TOKEN$/, /^npm_config_/,
+  /^AWS_/, /^GH_TOKEN$/, /^GITHUB_TOKEN$/, /^npm_config_/,
+  /^DATABASE_URL$/i, /^REDIS_URL$/i, /^MONGO_URI$/i,
+  /^SUPABASE_/, /^FIREBASE_/, /^STRIPE_/,
 ];
 
 /** Strip sensitive environment variables before passing to tools. */
@@ -662,8 +665,9 @@ export class AgentLoop {
       msg.includes('token limit') ||
       msg.includes('too many tokens') ||
       msg.includes('context window') ||
-      msg.includes('max_tokens') ||
-      (msg.includes('400') && msg.includes('token'))
+      msg.includes('prompt is too long') || // Anthropic
+      msg.includes('request too large') || // Generic
+      msg.includes('input is too long') // Google
     );
   }
 
@@ -681,7 +685,8 @@ export class AgentLoop {
       const result = await this.compressWithLLM(messages);
       compactedMessages = result.messages;
     } else {
-      const result = compressMessages(messages, messages.length, this.protectLastMessages);
+      // Force compression by passing threshold=0 (not messages.length which is a no-op)
+      const result = compressMessages(messages, 0, this.protectLastMessages);
       compactedMessages = result.messages;
     }
 
@@ -1215,7 +1220,7 @@ export class AgentLoop {
       if (this.shouldCompressTokenAware(nextMessages)) {
         const compression = this.compressionProvider
           ? await this.compressWithLLM(nextMessages)
-          : compressMessages(nextMessages, nextMessages.length, this.protectLastMessages);
+          : compressMessages(nextMessages, 0, this.protectLastMessages);
         if (compression.compressedCount > 0) {
           nextMessages.length = 0;
           nextMessages.push(...compression.messages);
@@ -1295,10 +1300,16 @@ export class AgentLoop {
       metadata: toolResults.length > 0 ? { toolCount: toolResults.length } : undefined
     });
 
+    // Strip transient memory prefix messages before persisting session
+    // (they are re-injected fresh each turn from the memory service)
+    const persistMessages = nextMessages.filter(m =>
+      !(m.role === 'system' && m.content.includes('<recalled-context'))
+    );
+
     // Track 2.2: Use LLM compression if provider is available, else heuristic
     const compression = this.compressionProvider
-      ? await this.compressWithLLM(nextMessages)
-      : compressMessages(nextMessages, this.compressAfterMessageCount, this.protectLastMessages);
+      ? await this.compressWithLLM(persistMessages)
+      : compressMessages(persistMessages, this.compressAfterMessageCount, this.protectLastMessages);
     const baseLineage = session.lineage ?? {
       rootSessionId: session.sessionId,
       compressionCount: 0

--- a/packages/runtime-node/src/index.ts
+++ b/packages/runtime-node/src/index.ts
@@ -127,11 +127,16 @@ export class GatewayDebouncer {
       existing.messages.push(text);
       // Reset the timer
       clearTimeout(existing.timer);
+      // Resolve the previous caller's promise with the same merged result
+      // (all callers for the same debounce window share the merged text)
+      const previousResolve = existing.resolve;
       return new Promise<string>((resolve) => {
         existing.resolve = resolve;
         existing.timer = setTimeout(() => {
           this.pending.delete(key);
-          resolve(existing.messages.join('\n'));
+          const merged = existing.messages.join('\n');
+          resolve(merged);
+          previousResolve(merged); // Resolve the previous caller too
         }, this.windowMs);
       });
     }


### PR DESCRIPTION
## Fixes from deep code review

### Critical (code didn't work):
- **C1/C2**: `compressMessages(msgs, msgs.length)` was no-op — threshold=0 for forced compression
- **C3**: Memory prefix accumulated in session each turn — filtered before persistence

### Weak (edge case failures):
- **W1**: GatewayDebouncer previous promise never resolved — all callers now resolve
- **W2**: `isContextOverflowError` matched auth errors — provider-specific patterns only
- **W3**: `sanitizeEnv` missed PRIVATE_KEY, DATABASE_URL, AWS_* — expanded coverage

191 files, 2143 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)