### PR TITLE
fix: guard sessionStorage for Node.js (CI publish fix)

### DIFF
--- a/packages/web/ui/src/lib/api.ts
+++ b/packages/web/ui/src/lib/api.ts
@@ -5,14 +5,16 @@
 
 const TOKEN_KEY = 'cc_auth_token';
 
-let authToken: string | null = sessionStorage.getItem(TOKEN_KEY);
+const storage = typeof sessionStorage !== 'undefined' ? sessionStorage : null;
+
+let authToken: string | null = storage?.getItem(TOKEN_KEY) ?? null;
 
 export const setAuthToken = (token: string | null) => {
   authToken = token;
   if (token) {
-    sessionStorage.setItem(TOKEN_KEY, token);
+    storage?.setItem(TOKEN_KEY, token);
   } else {
-    sessionStorage.removeItem(TOKEN_KEY);
+    storage?.removeItem(TOKEN_KEY);
   }
 };
 


### PR DESCRIPTION
sessionStorage.getItem() at module load crashes in Node.js CI. Wrapped with typeof check. Fixes publish workflow failure on v0.3.3 and v0.3.4.