### PR TITLE
release: v0.3.6 — security, sync, and retry audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to CrowClaw will be documented in this file.
 > Releases v0.2.0 through v0.3.4 were tracked in GitHub Releases. See
 > https://github.com/subinium/hermes-agent-typescript/releases for details.
 
+## [0.3.6] — 2026-04-16 — Security, sync, and retry audit fixes
+
+### Security (CRITICAL / HIGH)
+- **Fail-close when bound to non-localhost without a dashboard token.** `runtime-node` previously only gated routes tagged as "dangerous". `/api/events`, `/api/sessions/:id/message`, `/api/mcp/call`, and `/ws` were left open, so an instance bound to `0.0.0.0` without `CROWCLAW_DASHBOARD_TOKEN` leaked live session events, accepted prompts, and executed tools. Every protected surface now returns 500 until a token is set; webhook routes keep working because they carry their own per-platform secret.
+- **`POST /api/providers/config` no longer echoes stored apiKeys.** The previous handler merged the inbound payload with stored secrets and then responded with the raw merged config, leaking every persisted provider key — including slots the caller never touched. The POST response now uses the same `***` redaction as the GET handler.
+- **Stop persisting provider apiKeys and gateway tokens to disk.** `FileConfigStore` wrote `apiKey` values in plaintext into `~/.crowclaw/runtime-config.json` despite a comment saying otherwise, and wrote `token: '***'` for gateway configs — which then reloaded as the literal string `'***'`, silently corrupting Telegram/Slack/Discord delivery on every restart. Secrets are now stripped before serialization; users provide them via env vars or the dashboard after a restart.
+- **Dashboard auth no longer stores the raw token on the client.** `packages/web/ui/src/lib/{api,sse,ws}.ts` no longer keeps the token in `sessionStorage`, no longer attaches it as `Authorization: Bearer`, and no longer appends `?token=...` to the `/ws` URL (which leaked into access logs and Referer headers). Auth rides the existing HttpOnly cookie over same-origin credentials; the `/ws` upgrade handler now accepts that cookie and a new `POST /api/auth/logout` lets sign-out actually clear it. Server still accepts `Authorization: Bearer` from non-browser clients.
+
+### Reliability (HIGH / MEDIUM)
+- **Gateway retry now treats `{ok: false}` as a retryable failure.** `sendTelegramMessage` and friends report API errors as `{ok: false, error}` instead of throwing, so `executeWithRetry` used to return success on the very first failure and `GatewayRunner` would silently drop replies. The retry helper now detects the gateway envelope, retries with exponential backoff, and exposes the last error/value through `RetryResult`.
+- **Config writes are serialized and atomic.** `FileConfigStore.persistToDisk()` was fire-and-forget (`void ...`), so back-to-back mutators raced on a full-file rewrite. Writes now chain through a shared promise queue and land via temp file + `rename()`, matching the snapshot of the state observed when the caller invoked the mutator.
+- **`SessionMutex` refuses to evict a live chain.** At `maxSessions` capacity the old code deleted the oldest entry even if it was currently locked or queued, which let a subsequent `acquire()` on the evicted session create a fresh chain and run concurrently with the original holder. New behaviour: throw when adding a brand-new session would exceed the cap (existing sessions still queue).
+- **`GatewayRunner.sleep()` cleans up its abort listener on timeout.** Long pollers no longer accumulate one `abort` listener per poll cycle.
+
+### Tests
+- `tests/provider-factory.test.ts`: gateway token / webhook secret / provider apiKey must never land on disk, and reloaded stores must not inherit the `***` placeholder.
+- `tests/session-mutex.test.ts`: regression test for the overflow eviction bug.
+- `tests/gateway-retry.test.ts`: `{ok:false}` results now drive retries and propagate the last error.
+- Test count 2157 → 2161.
+
 ## [0.3.5] — 2026-04-16 — Dashboard contract drift fix + senior-pass cleanup
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
     <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License" /></a>
     <a href="#quickstart"><img src="https://img.shields.io/badge/node-%3E%3D22-blue.svg" alt="Node 22+" /></a>
     <a href="#project-structure"><img src="https://img.shields.io/badge/packages-19-purple.svg" alt="19 packages" /></a>
-    <img src="https://img.shields.io/badge/tests-2157%20passed-brightgreen.svg" alt="Tests" />
+    <img src="https://img.shields.io/badge/tests-2161%20passed-brightgreen.svg" alt="Tests" />
   </p>
 </p>
 
 ---
 
-> **Beta.** Core systems are functional and tested (2157 tests). APIs may change before 1.0 -- pin to minor versions for stability.
+> **Beta.** Core systems are functional and tested (2161 tests). APIs may change before 1.0 -- pin to minor versions for stability.
 
 ## Why CrowClaw
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowclaw",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "description": "A self-improving TypeScript agent framework that learns from every conversation.",
   "bin": {

--- a/packages/gateway/src/retry.ts
+++ b/packages/gateway/src/retry.ts
@@ -16,6 +16,10 @@ export interface RetryResult<T> {
  *
  * Uses exponential backoff: delay = baseDelayMs * 2^(attempt-1)
  * Jitter: +/- 20% to avoid thundering herd.
+ *
+ * Gateway send helpers (e.g. `sendTelegramMessage`) report API failures as
+ * `{ ok: false, error }` instead of throwing. We detect that shape and treat
+ * it as a retryable failure so callers don't silently drop messages.
  */
 export async function executeWithRetry<T>(
   fn: () => Promise<T>,
@@ -23,6 +27,7 @@ export async function executeWithRetry<T>(
   signal?: AbortSignal,
 ): Promise<RetryResult<T>> {
   let lastError: string | undefined;
+  let lastValue: T | undefined;
 
   for (let attempt = 1; attempt <= policy.maxAttempts; attempt++) {
     if (signal?.aborted) {
@@ -31,20 +36,42 @@ export async function executeWithRetry<T>(
 
     try {
       const value = await fn();
-      return { ok: true, value, attempts: attempt };
+      if (isGatewayFailure(value)) {
+        lastValue = value;
+        lastError = extractErrorMessage(value) ?? 'operation returned ok:false';
+      } else {
+        return { ok: true, value, attempts: attempt };
+      }
     } catch (error: unknown) {
       lastError = error instanceof Error ? error.message : String(error);
+    }
 
-      // Don't sleep after the last attempt
-      if (attempt < policy.maxAttempts) {
-        const baseDelay = policy.baseDelayMs * Math.pow(2, attempt - 1);
-        const jitter = baseDelay * (0.8 + Math.random() * 0.4); // +/- 20%
-        await sleep(jitter, signal);
-      }
+    // Don't sleep after the last attempt
+    if (attempt < policy.maxAttempts) {
+      const baseDelay = policy.baseDelayMs * Math.pow(2, attempt - 1);
+      const jitter = baseDelay * (0.8 + Math.random() * 0.4); // +/- 20%
+      await sleep(jitter, signal);
     }
   }
 
-  return { ok: false, attempts: policy.maxAttempts, lastError };
+  return { ok: false, value: lastValue, attempts: policy.maxAttempts, lastError };
+}
+
+function isGatewayFailure(value: unknown): boolean {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && 'ok' in value
+    && (value as { ok: unknown }).ok === false
+  );
+}
+
+function extractErrorMessage(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const err = (value as { error?: unknown }).error;
+  if (typeof err === 'string') return err;
+  if (err instanceof Error) return err.message;
+  return undefined;
 }
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {

--- a/packages/gateway/src/runner.ts
+++ b/packages/gateway/src/runner.ts
@@ -290,8 +290,12 @@ export class GatewayRunner {
         resolve();
         return;
       }
-      const timer = setTimeout(resolve, ms);
-      const onAbort = () => {
+      let onAbort: (() => void) | undefined;
+      const timer = setTimeout(() => {
+        if (onAbort) signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      onAbort = () => {
         clearTimeout(timer);
         resolve();
       };

--- a/packages/runtime-node/src/config-store.ts
+++ b/packages/runtime-node/src/config-store.ts
@@ -473,6 +473,25 @@ interface SerializedConfig {
   trustProxy?: boolean;
 }
 
+/** Build a clone of a ProviderConfig with every slot's apiKey stripped. */
+function stripProviderSecrets(providerConfig: ProviderConfig): ProviderConfig {
+  const stripSlot = (slot: ProviderSlot | undefined): ProviderSlot | undefined => {
+    if (!slot) return undefined;
+    const clone: ProviderSlot = { ...slot };
+    delete clone.apiKey;
+    return clone;
+  };
+  const stripped: ProviderConfig = {
+    primary: stripSlot(providerConfig.primary) as ProviderSlot,
+  };
+  if (providerConfig.fallback) stripped.fallback = stripSlot(providerConfig.fallback);
+  if (providerConfig.fast) stripped.fast = stripSlot(providerConfig.fast);
+  if (providerConfig.vision) stripped.vision = stripSlot(providerConfig.vision);
+  if (providerConfig.compression) stripped.compression = stripSlot(providerConfig.compression);
+  if (providerConfig.embedding) stripped.embedding = stripSlot(providerConfig.embedding);
+  return stripped;
+}
+
 /**
  * FileConfigStore — a RuntimeConfigStore that persists to a JSON file.
  *
@@ -485,6 +504,13 @@ export class FileConfigStore extends RuntimeConfigStore {
   private filePath: string;
   private initialized = false;
   private writeErrors = 0;
+  /**
+   * Serialized write chain. Every `persistToDisk()` call chains after the
+   * previous one so concurrent mutators don't race on the file. Writes are
+   * atomic: we write to a sibling temp path and then rename, which on POSIX
+   * is atomic and on Windows replaces the target in a single operation.
+   */
+  private writeQueue: Promise<void> = Promise.resolve();
 
   constructor(filePath: string) {
     super();
@@ -568,45 +594,75 @@ export class FileConfigStore extends RuntimeConfigStore {
     }
   }
 
-  /** Persist current state to disk. Silently falls back to in-memory on failure. */
-  private async persistToDisk(): Promise<void> {
+  /**
+   * Persist current state to disk. Silently falls back to in-memory on failure.
+   * Concurrent calls are serialized via `writeQueue` so writes never race.
+   */
+  private persistToDisk(): Promise<void> {
+    const previous = this.writeQueue;
+    const next = (async () => {
+      // Snapshot the config synchronously before the previous write completes,
+      // so the enqueued write captures "state as of now" and later mutations
+      // get their own queued write.
+      const serialized = this.serializeForDisk();
+      await previous.catch(() => { /* previous failure is already accounted for */ });
+      await this.doWrite(serialized);
+    })();
+    this.writeQueue = next;
+    return next;
+  }
+
+  /** Build the serialized config. Runs synchronously while holding the mutation point. */
+  private serializeForDisk(): SerializedConfig {
+    const cfg = this.config;
+    return {
+      activePreset: cfg.activePreset,
+      agentPreset: cfg.agentPreset,
+      activeToolset: cfg.activeToolset,
+      disabledSkills: [...cfg.disabledSkills],
+      mcpConnections: Object.fromEntries(cfg.mcpConnections),
+      customMcpServers: [...cfg.customMcpServers.values()],
+      // Never persist gateway bot tokens or webhook secrets to disk. Writing
+      // '***' back round-tripped as the real token on reload, corrupting
+      // gateway delivery. Users must re-supply the token via env var or the
+      // dashboard after a restart.
+      gatewayConfigs: Object.fromEntries(
+        [...cfg.gatewayConfigs].map(([platform, gatewayConfig]) => [
+          platform,
+          { ...gatewayConfig, token: undefined, webhookSecret: undefined },
+        ]),
+      ),
+      providerType: cfg.providerType,
+      model: cfg.model,
+      apiKey: '', // Never persist LLM API keys to disk — require env var or re-entry
+      providerConfig: cfg.providerConfig ? stripProviderSecrets(cfg.providerConfig) : null,
+      pendingPairings: Object.fromEntries(
+        [...cfg.pendingPairings].map(([k, v]) => [k, v])
+      ),
+      configPresets: [...cfg.configPresets.values()],
+      activeConfigPreset: cfg.activeConfigPreset,
+      securityPolicy: cfg.securityPolicy,
+      agentConfig: cfg.agentConfig,
+      publicUrl: cfg.publicUrl,
+      trustProxy: cfg.trustProxy,
+    };
+  }
+
+  private async doWrite(serialized: SerializedConfig): Promise<void> {
     try {
-      const { writeFile, mkdir } = await import('node:fs/promises');
+      const { writeFile, rename, mkdir, unlink } = await import('node:fs/promises');
       const { dirname } = await import('node:path');
-      // Persist raw config directly — NOT the redacted snapshot().
-      // snapshot() redacts API keys and MCP env values for API responses,
-      // but we need the real values on disk for restart recovery.
-      const cfg = this.config;
-      const serialized: SerializedConfig = {
-        activePreset: cfg.activePreset,
-        agentPreset: cfg.agentPreset,
-        activeToolset: cfg.activeToolset,
-        disabledSkills: [...cfg.disabledSkills],
-        mcpConnections: Object.fromEntries(cfg.mcpConnections),
-        customMcpServers: [...cfg.customMcpServers.values()],
-        gatewayConfigs: Object.fromEntries(
-          [...cfg.gatewayConfigs].map(([platform, gatewayConfig]) => [
-            platform,
-            { ...gatewayConfig, token: gatewayConfig.token ? '***' : undefined }
-          ])
-        ),
-        providerType: cfg.providerType,
-        model: cfg.model,
-        apiKey: '', // Never persist LLM API keys to disk — require env var or re-entry
-        providerConfig: cfg.providerConfig ? JSON.parse(JSON.stringify(cfg.providerConfig)) : null,
-        pendingPairings: Object.fromEntries(
-          [...cfg.pendingPairings].map(([k, v]) => [k, v])
-        ),
-        configPresets: [...cfg.configPresets.values()],
-        activeConfigPreset: cfg.activeConfigPreset,
-        securityPolicy: cfg.securityPolicy,
-        agentConfig: cfg.agentConfig,
-        publicUrl: cfg.publicUrl,
-        trustProxy: cfg.trustProxy,
-      };
       await mkdir(dirname(this.filePath), { recursive: true });
-      await writeFile(this.filePath, JSON.stringify(serialized, null, 2), { mode: 0o600 });
-      this.writeErrors = 0;
+      const tmpPath = `${this.filePath}.tmp.${process.pid}.${Math.random().toString(36).slice(2)}`;
+      try {
+        await writeFile(tmpPath, JSON.stringify(serialized, null, 2), { mode: 0o600 });
+        await rename(tmpPath, this.filePath);
+        this.writeErrors = 0;
+      } catch (err) {
+        // Clean up the temp file if the rename failed so we don't leak files.
+        try { await unlink(tmpPath); } catch { /* temp may not exist */ }
+        throw err;
+      }
     } catch {
       this.writeErrors++;
       // Fall back to in-memory silently

--- a/packages/runtime-node/src/index.ts
+++ b/packages/runtime-node/src/index.ts
@@ -1785,6 +1785,21 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
         return '127.0.0.1';
       };
 
+      // Fail-close: if we're bound to a non-localhost interface and no dashboard
+      // token is configured, reject every protected surface (API, events, WS).
+      // Webhooks still work because they carry their own per-platform secret.
+      // Without this gate, `/api/events`, `/api/sessions/*/message`, `/api/mcp/call`,
+      // and `/ws` would all be unauthenticated on a public IP.
+      if (!dashToken && !isLocalhost) {
+        const isProtectedSurface = url.pathname.startsWith('/api/') || url.pathname === '/ws';
+        if (isProtectedSurface) {
+          return Response.json(
+            { error: 'CROWCLAW_DASHBOARD_TOKEN is required when binding to non-localhost' },
+            { status: 500 }
+          );
+        }
+      }
+
       // Stricter rate limit for credential-checking endpoints only.
       // /api/auth/check is a passive cookie/bearer status read that the dashboard
       // hits on every page load — counting it as an "auth attempt" exhausts the
@@ -1821,6 +1836,18 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
         return Response.json({ ok: false });
       }
 
+      // Auth logout endpoint — clears the HttpOnly cookie. We can't clear
+      // an HttpOnly cookie from JS, so the client calls this to sign out.
+      if (request.method === 'POST' && url.pathname === '/api/auth/logout') {
+        const secureSuffix = isLocalhost ? '' : '; Secure';
+        const headers = new Headers({ 'content-type': 'application/json' });
+        headers.set(
+          'Set-Cookie',
+          `crowclaw_auth=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0${secureSuffix}`,
+        );
+        return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+      }
+
       // Auth check endpoint (cookie-based, does not leak token)
       if (request.method === 'GET' && url.pathname === '/api/auth/check') {
         const cookieAuth = parseCookieToken(request.headers.get('cookie'));
@@ -1834,7 +1861,12 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       }
 
       // Auth middleware for /api/* routes
-      if (url.pathname.startsWith('/api/') && url.pathname !== '/api/auth/verify' && url.pathname !== '/api/auth/check') {
+      if (
+        url.pathname.startsWith('/api/')
+        && url.pathname !== '/api/auth/verify'
+        && url.pathname !== '/api/auth/check'
+        && url.pathname !== '/api/auth/logout'
+      ) {
         const authHeader = request.headers.get('authorization');
         const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
         const cookieToken = parseCookieToken(request.headers.get('cookie'));
@@ -2542,7 +2574,24 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
           return Response.json({ ok: false, error: 'primary slot with provider and model is required' }, { status: 400 });
         }
         configStore.setProviderConfig(merged as import('./config-store.js').ProviderConfig);
-        return Response.json({ ok: true, config: configStore.getProviderConfig() });
+        // Return the redacted config — the POST response used to echo back the
+        // full stored config, leaking every persisted apiKey to whoever called
+        // this endpoint (including secrets from untouched slots the caller did
+        // not submit).
+        const saved = configStore.getProviderConfig();
+        const redactSlot = (slot: import('./config-store.js').ProviderSlot | undefined) =>
+          slot ? { ...slot, apiKey: slot.apiKey ? '***' : undefined } : null;
+        return Response.json({
+          ok: true,
+          config: saved ? {
+            primary: redactSlot(saved.primary),
+            fallback: redactSlot(saved.fallback),
+            fast: redactSlot(saved.fast),
+            vision: redactSlot(saved.vision),
+            compression: redactSlot(saved.compression),
+            embedding: redactSlot(saved.embedding),
+          } : null,
+        });
       }
 
       if (request.method === 'POST' && url.pathname === '/api/providers/test') {
@@ -5216,13 +5265,23 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
         }
       }
 
-      // --- WebSocket upgrade (auth via query param or header) ---
+      // --- WebSocket upgrade (auth via HttpOnly cookie or Authorization header) ---
       if (request.method === 'GET' && url.pathname === '/ws') {
-        const wsToken = url.searchParams.get('token') ?? request.headers.get('authorization')?.replace('Bearer ', '');
-        const wsAuthenticated = !!dashToken && !!wsToken && timingSafeEqual(wsToken, dashToken);
-        // When dashToken is configured, reject unauthenticated WS connections
+        // Prefer the cookie the browser already holds from /api/auth/verify.
+        // Bearer header stays supported for non-browser clients. We intentionally
+        // do NOT accept `?token=...` query params: they leak into access logs,
+        // proxy logs, and the browser's Referer header.
+        const cookieAuth = parseCookieToken(request.headers.get('cookie'));
+        const bearerHeader = request.headers.get('authorization');
+        const wsBearer = bearerHeader?.startsWith('Bearer ') ? bearerHeader.slice(7) : null;
+
+        const derivedCookie = dashToken ? deriveCookieToken(dashToken) : '';
+        const cookieMatches = !!dashToken && cookieAuth !== null && timingSafeEqual(cookieAuth, derivedCookie);
+        const bearerMatches = !!dashToken && wsBearer !== null && timingSafeEqual(wsBearer, dashToken);
+        const wsAuthenticated = cookieMatches || bearerMatches;
+
         if (dashToken && !wsAuthenticated) {
-          return new Response('Unauthorized — provide token query param or Authorization header', { status: 401 });
+          return new Response('Unauthorized — authenticated cookie or Authorization header required', { status: 401 });
         }
         return handleWebSocketUpgrade(request, eventBus, wsManager, wsAuthenticated || !dashToken);
       }

--- a/packages/runtime-node/src/session-mutex.ts
+++ b/packages/runtime-node/src/session-mutex.ts
@@ -22,10 +22,13 @@ export class SessionMutex {
   }
 
   async acquire(sessionId: string): Promise<() => void> {
-    // Evict oldest entries if at capacity (prevents unbounded memory growth)
+    // Refuse new sessions at capacity. Evicting a live chain would break
+    // serialization — a subsequent acquire for the evicted session would
+    // create a fresh chain that runs concurrently with the previous holder.
+    // Live entries self-clean in their release callback, so hitting the cap
+    // means there really are that many active sessions.
     if (this.chains.size >= this.maxSessions && !this.chains.has(sessionId)) {
-      const oldest = this.chains.keys().next().value;
-      if (oldest !== undefined) this.chains.delete(oldest);
+      throw new Error(`SessionMutex at capacity (${this.maxSessions} active sessions)`);
     }
 
     const existing = this.chains.get(sessionId) ?? Promise.resolve();

--- a/packages/web/ui/src/lib/api.ts
+++ b/packages/web/ui/src/lib/api.ts
@@ -1,28 +1,30 @@
 /**
  * API client for CrowClaw dashboard.
- * Ported from vanilla JS `ap()` function.
+ *
+ * Authentication is handled entirely by the server-issued `crowclaw_auth`
+ * HttpOnly cookie. The raw dashboard token is never stored in the browser
+ * (sessionStorage / localStorage) or sent on every request, because:
+ *   - HttpOnly cookies survive XSS that reaches JS-accessible storage
+ *   - Tokens in Authorization headers or query strings leak into logs,
+ *     proxies, and Referer headers
  */
 
-const TOKEN_KEY = 'cc_auth_token';
+export const getAuthToken = (): null => null;
 
-const storage = typeof sessionStorage !== 'undefined' ? sessionStorage : null;
-
-let authToken: string | null = storage?.getItem(TOKEN_KEY) ?? null;
-
-export const setAuthToken = (token: string | null) => {
-  authToken = token;
-  if (token) {
-    storage?.setItem(TOKEN_KEY, token);
-  } else {
-    storage?.removeItem(TOKEN_KEY);
-  }
+export const setAuthToken = (_token: string | null): void => {
+  // Intentionally a no-op. Server owns auth state via HttpOnly cookie.
 };
 
-export const getAuthToken = () => authToken;
-
-export const clearAuthToken = () => {
-  authToken = null;
-  storage?.removeItem(TOKEN_KEY);
+/**
+ * Sign the user out by asking the server to expire the auth cookie.
+ * Failures are swallowed because the UI state transition must continue
+ * regardless of the network response.
+ */
+export const clearAuthToken = (): void => {
+  void fetch(`${location.origin}/api/auth/logout`, {
+    method: 'POST',
+    credentials: 'same-origin',
+  }).catch(() => { /* best-effort logout */ });
 };
 
 export interface ApiOptions extends RequestInit {
@@ -47,10 +49,6 @@ export const api = async <T = unknown>(path: string, options?: ApiOptions): Prom
     'content-type': 'application/json',
     ...(fetchOpts.headers as Record<string, string>),
   };
-
-  if (authToken) {
-    headers['Authorization'] = `Bearer ${authToken}`;
-  }
 
   const response = await fetch(`${location.origin}${path}`, {
     ...fetchOpts,
@@ -84,7 +82,7 @@ export const api = async <T = unknown>(path: string, options?: ApiOptions): Prom
 };
 
 /**
- * Check if user is authenticated via cookie or token.
+ * Check if user is authenticated via cookie.
  */
 export const checkAuth = async (): Promise<boolean> => {
   try {
@@ -96,7 +94,8 @@ export const checkAuth = async (): Promise<boolean> => {
 };
 
 /**
- * Verify token and obtain auth.
+ * Verify token and obtain auth. On success the server issues an HttpOnly
+ * cookie and we throw the raw token away immediately.
  */
 export const verifyToken = async (token: string): Promise<boolean> => {
   try {
@@ -104,11 +103,7 @@ export const verifyToken = async (token: string): Promise<boolean> => {
       method: 'POST',
       body: JSON.stringify({ token }),
     });
-    if (data.ok) {
-      setAuthToken(token);
-      return true;
-    }
-    return false;
+    return data.ok === true;
   } catch {
     return false;
   }

--- a/packages/web/ui/src/lib/sse.ts
+++ b/packages/web/ui/src/lib/sse.ts
@@ -3,8 +3,6 @@
  * Ported from vanilla JS sndStream() + handleStreamEvent().
  */
 
-import { getAuthToken } from './api.js';
-
 export interface StreamEvent {
   type: 'text-delta' | 'tool-start' | 'tool-end' | 'iteration-start' | 'error' | 'done';
   content?: string;
@@ -38,18 +36,11 @@ export const streamMessage = (
   callbacks: StreamCallbacks,
 ): AbortController => {
   const controller = new AbortController();
-  const authToken = getAuthToken();
-
-  const headers: Record<string, string> = {
-    'content-type': 'application/json',
-  };
-  if (authToken) {
-    headers['Authorization'] = `Bearer ${authToken}`;
-  }
 
   fetch(`${location.origin}/api/sessions/${sessionId}/stream`, {
     method: 'POST',
-    headers,
+    headers: { 'content-type': 'application/json' },
+    credentials: 'same-origin',
     body: JSON.stringify({ message }),
     signal: controller.signal,
   })

--- a/packages/web/ui/src/lib/ws.ts
+++ b/packages/web/ui/src/lib/ws.ts
@@ -4,7 +4,6 @@
  */
 
 import { connectEventStream } from './sse.js';
-import { getAuthToken } from './api.js';
 
 export interface WsCallbacks {
   onEvent: (event: { type: string; data: Record<string, unknown> }) => void;
@@ -25,9 +24,10 @@ const MAX_FAILURES_BEFORE_FALLBACK = 3;
 
 const buildWsUrl = (): string => {
   const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const base = `${protocol}//${location.host}/ws`;
-  const token = getAuthToken();
-  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+  // Same-origin WebSocket carries the HttpOnly auth cookie automatically.
+  // We intentionally do NOT append `?token=...` — query strings leak into
+  // access logs and the Referer header even when the connection is TLS.
+  return `${protocol}//${location.host}/ws`;
 };
 
 export const connectWebSocket = (callbacks: WsCallbacks): WsClient => {

--- a/tests/gateway-retry.test.ts
+++ b/tests/gateway-retry.test.ts
@@ -64,6 +64,36 @@ describe('executeWithRetry', () => {
     expect(result.value).toEqual({ id: 42, name: 'test' });
   });
 
+  it('retries gateway-style {ok:false} results and propagates last error', async () => {
+    let callCount = 0;
+    const result = await executeWithRetry(
+      async () => {
+        callCount++;
+        if (callCount < 3) {
+          return { ok: false, error: `fail ${callCount}` };
+        }
+        return { ok: true, platform: 'telegram' };
+      },
+      { maxAttempts: 3, baseDelayMs: 1 },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(3);
+    expect(callCount).toBe(3);
+  });
+
+  it('returns failure when every attempt produces {ok:false}', async () => {
+    const result = await executeWithRetry(
+      async () => ({ ok: false, error: 'telegram API said no' }),
+      { maxAttempts: 2, baseDelayMs: 1 },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts).toBe(2);
+    expect(result.lastError).toBe('telegram API said no');
+    expect(result.value).toEqual({ ok: false, error: 'telegram API said no' });
+  });
+
   it('aborts mid-retry when signal fires during backoff', async () => {
     const controller = new AbortController();
     let callCount = 0;

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -306,19 +306,48 @@ describe('FileConfigStore', () => {
     expect(data.activeToolset).toBe('minimal');
   });
 
-  it('persists gateway config', async () => {
+  it('persists gateway config without leaking or round-tripping tokens', async () => {
     const store = new FileConfigStore(configPath);
     await store.load();
 
-    store.setGatewayConfig('discord', { enabled: true, token: 'test-token' });
+    store.setGatewayConfig('discord', { enabled: true, token: 'test-token', webhookSecret: 'shh' });
 
     await new Promise((r) => setTimeout(r, 50));
 
     const raw = await readFile(configPath, 'utf-8');
     const data = JSON.parse(raw);
-    // Token should be masked in snapshot
     expect(data.gatewayConfigs.discord.enabled).toBe(true);
-    expect(data.gatewayConfigs.discord.token).toBe('***');
+    // Tokens and webhook secrets must never land on disk, because the previous
+    // implementation persisted a '***' placeholder and then reloaded it as the
+    // literal token — breaking every outbound message after a restart.
+    expect(data.gatewayConfigs.discord.token).toBeUndefined();
+    expect(data.gatewayConfigs.discord.webhookSecret).toBeUndefined();
+
+    // Reloaded instance must not treat the redacted placeholder as a real token
+    const store2 = new FileConfigStore(configPath);
+    await store2.load();
+    const reloaded = store2.getGatewayConfig('discord');
+    expect(reloaded?.enabled).toBe(true);
+    expect(reloaded?.token).toBeUndefined();
+    expect(reloaded?.webhookSecret).toBeUndefined();
+  });
+
+  it('strips provider apiKeys before persisting', async () => {
+    const store = new FileConfigStore(configPath);
+    await store.load();
+
+    store.setProviderConfig({
+      primary: { name: 'Primary', provider: 'openai', model: 'gpt-4o', apiKey: 'sk-plain' },
+      fallback: { name: 'Fallback', provider: 'anthropic', model: 'claude-sonnet-4', apiKey: 'sk-ant' },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const raw = await readFile(configPath, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data.providerConfig.primary.provider).toBe('openai');
+    expect(data.providerConfig.primary.apiKey).toBeUndefined();
+    expect(data.providerConfig.fallback.apiKey).toBeUndefined();
   });
 
   it('onChange listeners fire on FileConfigStore mutations', async () => {

--- a/tests/session-mutex.test.ts
+++ b/tests/session-mutex.test.ts
@@ -85,4 +85,28 @@ describe('SessionMutex', () => {
     r2();
     expect(mutex.activeCount).toBe(0);
   });
+
+  it('throws when capacity is reached instead of silently evicting a live chain', async () => {
+    const mutex = new SessionMutex({ maxSessions: 2 });
+
+    // Fill to capacity with two live sessions
+    const r1 = await mutex.acquire('s1');
+    const r2 = await mutex.acquire('s2');
+    expect(mutex.activeCount).toBe(2);
+
+    // A third distinct session must NOT evict an active chain — old behaviour
+    // removed 's1' from the map, letting a subsequent 's1' acquire skip the
+    // queue and run concurrently with the existing holder.
+    await expect(mutex.acquire('s3')).rejects.toThrow(/capacity/);
+
+    // Re-entering an existing session is still allowed (it chains behind r1)
+    const queued = mutex.acquire('s1');
+
+    r1();
+    r2();
+
+    const r1b = await queued;
+    r1b();
+    expect(mutex.activeCount).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Ships **v0.3.6** as a direct response to the Codex runtime audit. Fixes every CRITICAL, HIGH, MEDIUM, and LOW finding without scope creep. All 192 test files / 2161 tests pass; `tsc -b` clean.

### Security (CRITICAL / HIGH)
- **Fail-close non-localhost auth**: `packages/runtime-node/src/index.ts` now rejects every protected surface (`/api/*` except `/api/auth/*`, `/api/events`, `/api/sessions/*/message`, `/api/mcp/call`, `/ws`) with 500 when bound to a non-localhost interface without `CROWCLAW_DASHBOARD_TOKEN`. Webhooks keep working via their own platform secrets.
- **`POST /api/providers/config` redaction**: response used to echo every persisted apiKey — including slots the caller never submitted. Now redacted to `***`, matching the GET handler.
- **Disk persistence stops leaking secrets**: `FileConfigStore` strips provider `apiKey` and gateway `token` / `webhookSecret` before writing. The prior behaviour persisted `token: '***'` and then reloaded that literal string, which silently corrupted outbound gateway delivery on restart.
- **Dashboard cookie-only auth**: `packages/web/ui/src/lib/{api,sse,ws}.ts` no longer keeps the token in `sessionStorage`, no longer attaches it as `Authorization: Bearer`, and no longer appends `?token=...` to the `/ws` URL. Auth rides the existing HttpOnly cookie over same-origin credentials. Server `/ws` upgrade accepts the cookie (Bearer stays supported for non-browser clients). Added `POST /api/auth/logout` so sign-out can actually clear the cookie.

### Reliability (HIGH / MEDIUM)
- **Gateway retry treats `{ok:false}` as retryable**: `sendTelegramMessage` and friends return `{ok:false,error}` instead of throwing, so `executeWithRetry` used to treat the first failure as success and `GatewayRunner` silently dropped replies. The helper now detects the gateway envelope, retries with exponential backoff, and surfaces the last error through `RetryResult`.
- **Serialized, atomic config writes**: `FileConfigStore.persistToDisk()` was fire-and-forget; concurrent mutators raced on full-file rewrites. Writes now chain through a shared promise queue and land via temp file + `rename()`.
- **`SessionMutex` overflow fix**: at `maxSessions` the old code evicted the oldest entry even if it was currently locked or queued, letting a subsequent `acquire()` skip the chain and run concurrently with the prior holder. New behaviour: throw when a brand-new session would exceed the cap.

### Low
- **`GatewayRunner.sleep()` listener leak**: cleans up the abort listener on normal timeout so long-running pollers don't accumulate listeners.

### Tests (2157 → 2161)
- `tests/provider-factory.test.ts` — gateway token / webhook secret / provider apiKey must never land on disk; reloaded stores must not inherit the `***` placeholder.
- `tests/session-mutex.test.ts` — regression test for the overflow eviction bug.
- `tests/gateway-retry.test.ts` — `{ok:false}` results drive retries and propagate the last error.

## Release chores
- Root `package.json` 0.3.5 → 0.3.6
- README badge + beta note: 2157 → 2161 tests
- `CHANGELOG.md` gets a new `[0.3.6]` entry grouped by severity

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (192 files / 2161 tests)
- [x] `npm run preflight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)