### PR TITLE
release: v0.4.2 — CF drift, trusted-proxy, memory/checkpoint perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to CrowClaw will be documented in this file.
 > Releases v0.2.0 through v0.3.4 were tracked in GitHub Releases. See
 > https://github.com/subinium/hermes-agent-typescript/releases for details.
 
+## [0.4.2] — 2026-04-17 — Cloudflare drift + trusted-proxy + memory / checkpoint perf
+
+Third pass on the v0.4.0 deferred backlog. Closes the three easy-to-see CF contract gaps from the contract audit, adds a real trusted-proxy allowlist for the auth throttle, and cuts the two biggest hot-path allocations (`InMemoryMemoryStore.write` and redundant checkpoint message clones).
+
+### Security (HIGH)
+- **Trusted-proxy allowlist.** `CROWCLAW_TRUSTED_PROXIES=10.0.0.1,10.0.0.2` gates `X-Forwarded-For` trust: with `trustProxy` on, the runtime now reads the TCP remote address (injected by the CLI's HTTP wrapper as `x-crowclaw-remote-addr`) and only honors the forwarded header when the remote address is in the allowlist. Without this, a caller reaching the exposed port directly could spoof XFF and rotate past the per-IP rate limiter even after the v0.4.1 global backstop. The CLI strips any client-supplied `x-crowclaw-remote-addr` before forwarding, so the header can't be forged.
+
+### Reliability (Cloudflare parity)
+- **`/api/system/status.counts` shape matched to Node.** Added `bridgeProcesses` and `bridgeAliveProcesses` (both reported as `0` on CF since Durable Objects don't manage host processes) and dropped the non-Node `sessions` field. Overview panel counts now render on CF without `undefined` fallbacks.
+- **`/api/skills` now returns `requiredTools`.** Skill-tool-chip row on the Agent view stopped rendering empty on CF deployments.
+- **`/api/presets` returns `activeAgent` / `activeToolset` / `activeMcp`.** Previously returned only the preset lists; CF UI couldn't mark any preset as active. Fields are `null` until the CF runtime learns to persist the active selection (v0.4.3 scope).
+
+### Performance
+- **`InMemoryMemoryStore.write()` went from O(n) to O(1) per record.** Previous code ran `[...current, record]` on every insert, so a session with 1000 memories allocated a fresh 1000-element array on the 1001st write. Now mutates the bucket in place.
+- **Pre-indexed memory search.** Each record stores a lowercased `summary + tags + metadata JSON` blob (cached on first access via a `Symbol` field) so `matchesQuery` becomes a single `includes()` instead of running `JSON.stringify(metadata).toLowerCase()` per-record per-search.
+- **`searchByScope` / `listByScope`** no longer `[...this.store.values()].flat()` — single pass that filters scope and query in one loop.
+- **Checkpoint creation: dropped the redundant pre-clone.** `createCheckpoint({ ...session, messages: [...nextMessages] }, ...)` in five call sites cloned `nextMessages` then the function cloned it again via `structuredClone`. Removed the `[...nextMessages]` spread; the in-function clone is still authoritative, so stored checkpoints are still independent of live session state.
+
+### Tests
+- 2161/2161 passing. All changes are internal contract or perf — public shapes remain the same except `/api/system/status.counts` (added fields) and `/api/presets` (added `active*` fields), both UI-additive.
+
+### Still deferred (v0.4.3+)
+- CSP `style-src 'unsafe-inline'` → nonce (requires inline-style audit of the Lit dashboard; nonce + unsafe-inline is mutually exclusive in strict CSP3).
+- `runtime-node/src/index.ts` 5400-line split.
+- Cloudflare full endpoint parity (~25 routes still missing: auth, config, security, providers, MCP CRUD, scheduler lifecycle, gateway admin).
+- `EmbeddingMemoryStore.search` linear scan at 10k+ vectors.
+- Full CIDR support for trusted-proxy (current allowlist is exact-match only).
+- Dashboard HTML parser-based nonce injection (replace the current regex, which has known edge cases on future `<script>` patterns).
+
 ## [0.4.1] — 2026-04-17 — Deferred audit items from v0.4.0
 
 Follow-up release draining the "deferred to v0.4.1" backlog that v0.4.0 explicitly carved out.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowclaw",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "A self-improving TypeScript agent framework that learns from every conversation.",
   "bin": {

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/acp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.1"
+    "@crowclaw/core": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2613,6 +2613,14 @@ export async function runServe(options: CliRunOptions & { port?: number } = {}):
         if (typeof value === 'string') headers.set(key, value);
         else if (Array.isArray(value)) headers.set(key, value.join(', '));
       }
+      // Pass the raw socket remote address into the runtime so the trusted-proxy
+      // check in getClientIp() can compare against CROWCLAW_TRUSTED_PROXIES.
+      // Strip any client-supplied value first — otherwise a caller could send
+      // `x-crowclaw-remote-addr: 127.0.0.1` to spoof it.
+      headers.delete('x-crowclaw-remote-addr');
+      if (req.socket?.remoteAddress) {
+        headers.set('x-crowclaw-remote-addr', req.socket.remoteAddress);
+      }
 
       const bodyChunks: Buffer[] = [];
       for await (const chunk of req) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/core",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -22,6 +22,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/plugins": "0.4.1"
+    "@crowclaw/plugins": "0.4.2"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1137,7 +1137,7 @@ export class AgentLoop {
           const def = this.tools.get(tc.name);
           const dangerousSignals = collectDangerousInputSignals(tc.input);
           if (def?.manifest.dangerLevel === 'high' || dangerousSignals.length > 0) {
-            await this.checkpointStore.save(createCheckpoint({ ...session, messages: [...nextMessages] }, toolResults, iteration, 'pre-dangerous'));
+            await this.checkpointStore.save(createCheckpoint({ ...session, messages: nextMessages }, toolResults, iteration, 'pre-dangerous'));
             break; // Only one pre-dangerous checkpoint per iteration
           }
         }
@@ -1264,7 +1264,7 @@ export class AgentLoop {
 
       // Track 1.4: Auto-checkpoint at end of iteration
       if (this.autoCheckpoint && this.checkpointStore) {
-        await this.checkpointStore.save(createCheckpoint({ ...session, messages: [...nextMessages] }, toolResults, iteration, 'iteration'));
+        await this.checkpointStore.save(createCheckpoint({ ...session, messages: nextMessages }, toolResults, iteration, 'iteration'));
       }
 
       // Tiered budget warnings (Hermes pattern) — inject ephemeral hints
@@ -1718,7 +1718,7 @@ export class AgentLoop {
             if (needsApproval) {
               // Track 1.4: Checkpoint before dangerous tool
               if (this.autoCheckpoint && this.checkpointStore) {
-                await this.checkpointStore.save(createCheckpoint({ ...session, messages: [...nextMessages] }, toolResults, iteration, 'pre-dangerous'));
+                await this.checkpointStore.save(createCheckpoint({ ...session, messages: nextMessages }, toolResults, iteration, 'pre-dangerous'));
               }
 
               const context: ToolExecutionContext = {
@@ -1800,7 +1800,7 @@ export class AgentLoop {
 
         // Track 1.4: Auto-checkpoint at end of iteration
         if (this.autoCheckpoint && this.checkpointStore) {
-          await this.checkpointStore.save(createCheckpoint({ ...session, messages: [...nextMessages] }, toolResults, iteration, 'iteration'));
+          await this.checkpointStore.save(createCheckpoint({ ...session, messages: nextMessages }, toolResults, iteration, 'iteration'));
         }
 
         streamIterationsCompleted = iteration + 1;
@@ -1837,7 +1837,7 @@ export class AgentLoop {
       // Save completion checkpoint
       if (this.autoCheckpoint && this.checkpointStore) {
         await this.checkpointStore.save(
-          createCheckpoint({ ...session, messages: [...nextMessages] }, toolResults, this.maxToolIterations, 'completion')
+          createCheckpoint({ ...session, messages: nextMessages }, toolResults, this.maxToolIterations, 'completion')
         );
       }
       yield { type: 'done', response: finalResponse, usage: accumulatedUsage };

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/gateway",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/learning",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,6 +18,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.1"
+    "@crowclaw/core": "0.4.2"
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.1"
+    "@crowclaw/core": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/sandbox-executor": "0.4.1"
+    "@crowclaw/sandbox-executor": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/memory",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.1",
-    "@crowclaw/storage": "0.4.1"
+    "@crowclaw/core": "0.4.2",
+    "@crowclaw/storage": "0.4.2"
   }
 }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/plugins",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/providers",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,6 +18,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.1"
+    "@crowclaw/core": "0.4.2"
   }
 }

--- a/packages/runtime-cloudflare/package.json
+++ b/packages/runtime-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/runtime-cloudflare",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -19,18 +19,18 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.8.9",
-    "@crowclaw/core": "0.4.1",
-    "@crowclaw/memory": "0.4.1",
-    "@crowclaw/providers": "0.4.1",
-    "@crowclaw/sandbox-executor": "0.4.1",
-    "@crowclaw/shared": "0.4.1",
-    "@crowclaw/storage": "0.4.1",
-    "@crowclaw/tools": "0.4.1",
-    "@crowclaw/gateway": "0.4.1",
-    "@crowclaw/workspace": "0.4.1",
-    "@crowclaw/learning": "0.4.1",
-    "@crowclaw/mcp": "0.4.1",
-    "@crowclaw/scheduler": "0.4.1",
-    "@crowclaw/plugins": "0.4.1"
+    "@crowclaw/core": "0.4.2",
+    "@crowclaw/memory": "0.4.2",
+    "@crowclaw/providers": "0.4.2",
+    "@crowclaw/sandbox-executor": "0.4.2",
+    "@crowclaw/shared": "0.4.2",
+    "@crowclaw/storage": "0.4.2",
+    "@crowclaw/tools": "0.4.2",
+    "@crowclaw/gateway": "0.4.2",
+    "@crowclaw/workspace": "0.4.2",
+    "@crowclaw/learning": "0.4.2",
+    "@crowclaw/mcp": "0.4.2",
+    "@crowclaw/scheduler": "0.4.2",
+    "@crowclaw/plugins": "0.4.2"
   }
 }

--- a/packages/runtime-cloudflare/src/agent-do.ts
+++ b/packages/runtime-cloudflare/src/agent-do.ts
@@ -314,10 +314,15 @@ export class AgentSessionDurableObject {
         gateway: {
           slackSigningSecretConfigured: Boolean(this.env.SLACK_SIGNING_SECRET)
         },
+        // Counts shape matches Node's `summarizeSessionRecord` so the
+        // Overview panel renders the same fields on both runtimes. Prior
+        // CF response omitted bridgeProcesses / bridgeAliveProcesses and
+        // carried a `sessions` key that Node did not.
         counts: {
-          sessions: sessions.length,
-          browserSessions: this.browserSessions.size,
           bridgeSessions: this.codeBridgeSessions.size,
+          bridgeProcesses: 0,
+          bridgeAliveProcesses: 0,
+          browserSessions: this.browserSessions.size,
           schedulerJobs: (await this.schedulerStore.listJobs()).length
         }
       });
@@ -328,11 +333,14 @@ export class AgentSessionDurableObject {
       const allSkills = this.skillRegistry.resolveAll();
       const stats = this.skillRegistry.stats();
       return Response.json({
+        // `requiredTools` mirrors Node runtime so the Agent view can render
+        // tool-chip rows on skill cards (was empty on CF deployments).
         skills: allSkills.map(({ skill, enabled }) => ({
           slug: skill.manifest.name,
           title: this.skillRegistry.getDisplayTitle(skill.manifest.name) ?? skill.manifest.name,
           summary: skill.manifest.description,
           triggerPhrases: skill.manifest.triggers,
+          requiredTools: skill.manifest.tools ?? [],
           status: this.skillRegistry.getStatus(skill.manifest.name) ?? 'published',
           source: (skill.manifest.category as 'builtin' | 'learned' | 'local') ?? 'builtin',
           enabled,
@@ -344,10 +352,15 @@ export class AgentSessionDurableObject {
 
     if (request.method === 'GET' && url.pathname.endsWith('/presets')) {
       const mcpNames = listMcpPresetNames();
+      // `activeAgent`/`activeToolset`/`activeMcp` fields let the Agent view
+      // decorate the "Active" badge. CF previously returned only the lists.
       return Response.json({
         agents: listAgentPresets(),
         toolsets: listToolsetPresets(),
-        mcp: mcpNames.map((name) => ({ name, description: getMcpPresetDescription(name) }))
+        mcp: mcpNames.map((name) => ({ name, description: getMcpPresetDescription(name) })),
+        activeAgent: null,
+        activeToolset: null,
+        activeMcp: null,
       });
     }
 

--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/runtime-node",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -34,18 +34,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/acp": "0.4.1",
-    "@crowclaw/core": "0.4.1",
-    "@crowclaw/gateway": "0.4.1",
-    "@crowclaw/learning": "0.4.1",
-    "@crowclaw/mcp": "0.4.1",
-    "@crowclaw/mcp-server": "0.4.1",
-    "@crowclaw/memory": "0.4.1",
-    "@crowclaw/plugins": "0.4.1",
-    "@crowclaw/providers": "0.4.1",
-    "@crowclaw/scheduler": "0.4.1",
-    "@crowclaw/storage": "0.4.1",
-    "@crowclaw/tools": "0.4.1",
-    "@crowclaw/workspace": "0.4.1"
+    "@crowclaw/acp": "0.4.2",
+    "@crowclaw/core": "0.4.2",
+    "@crowclaw/gateway": "0.4.2",
+    "@crowclaw/learning": "0.4.2",
+    "@crowclaw/mcp": "0.4.2",
+    "@crowclaw/mcp-server": "0.4.2",
+    "@crowclaw/memory": "0.4.2",
+    "@crowclaw/plugins": "0.4.2",
+    "@crowclaw/providers": "0.4.2",
+    "@crowclaw/scheduler": "0.4.2",
+    "@crowclaw/storage": "0.4.2",
+    "@crowclaw/tools": "0.4.2",
+    "@crowclaw/workspace": "0.4.2"
   }
 }

--- a/packages/runtime-node/src/index.ts
+++ b/packages/runtime-node/src/index.ts
@@ -1746,14 +1746,33 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       const dashToken = (globalThis as unknown as { process?: { env?: Record<string, string | undefined> } }).process?.env?.CROWCLAW_DASHBOARD_TOKEN;
       const bindHostname = options.hostname ?? '127.0.0.1';
       const isLocalhost = isLocalhostAddress(bindHostname);
-      // Extract client IP — reads trustProxy from configStore (persisted, dynamic)
+      // Extract client IP — reads trustProxy from configStore (persisted, dynamic).
+      //
+      // Trusted-proxy allowlist (v0.4.2+): when trustProxy is on AND the caller
+      // sets CROWCLAW_TRUSTED_PROXIES=<comma-separated IPs>, we only honor
+      // X-Forwarded-For if the upstream remote address (injected by the Node HTTP
+      // wrapper as `x-crowclaw-remote-addr`) is in that list. Without this, an
+      // attacker who reaches the exposed port directly can spoof X-Forwarded-For
+      // to rotate source IPs past the per-IP rate limiter. If trustProxy is on
+      // but no allowlist is configured, we keep the legacy behavior (full trust)
+      // but the global 60/min auth backstop from v0.4.1 still applies.
+      const trustedProxiesRaw = (globalThis as unknown as { process?: { env?: Record<string, string | undefined> } })
+        .process?.env?.CROWCLAW_TRUSTED_PROXIES;
+      const trustedProxies = trustedProxiesRaw
+        ? new Set(trustedProxiesRaw.split(',').map((s) => s.trim()).filter(Boolean))
+        : null;
       const getClientIp = (req: Request): string => {
+        const remoteAddr = req.headers.get('x-crowclaw-remote-addr') ?? '127.0.0.1';
         if (configStore.getTrustProxy() || options.trustProxy) {
+          if (trustedProxies && !trustedProxies.has(remoteAddr)) {
+            // Remote addr is not in the allowlist — don't trust the header.
+            return remoteAddr;
+          }
           return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
             ?? req.headers.get('x-real-ip')
-            ?? '127.0.0.1';
+            ?? remoteAddr;
         }
-        return '127.0.0.1';
+        return remoteAddr;
       };
 
       // Fail-close: if we're bound to a non-localhost interface and no dashboard

--- a/packages/sandbox-executor/package.json
+++ b/packages/sandbox-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/sandbox-executor",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.8.9",
-    "@crowclaw/core": "0.4.1",
-    "@crowclaw/tools": "0.4.1"
+    "@crowclaw/core": "0.4.2",
+    "@crowclaw/tools": "0.4.2"
   }
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/scheduler",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/shared",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/storage",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,8 +18,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.1",
-    "@crowclaw/shared": "0.4.1"
+    "@crowclaw/core": "0.4.2",
+    "@crowclaw/shared": "0.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -46,15 +46,30 @@ function matchesScope(record: MemoryRecord, scope: MemoryRecord['scope'], scopeK
   return record.scope === scope && (!scopeKey || record.scopeKey === scopeKey);
 }
 
+/**
+ * Pre-index a record's searchable text once at write time so `matchesQuery`
+ * can skip repeated `JSON.stringify(metadata).toLowerCase()` on every search.
+ * We stash it on a weakly-typed symbol field so the serialized MemoryRecord
+ * shape stays stable across storage boundaries.
+ */
+const SEARCH_BLOB = Symbol('searchBlob');
+type IndexedRecord = MemoryRecord & { [SEARCH_BLOB]?: string };
+
+function buildSearchBlob(record: MemoryRecord): string {
+  return `${record.summary}\n${record.tags.join('\n')}\n${JSON.stringify(record.metadata ?? {})}`.toLowerCase();
+}
+
+function getSearchBlob(record: IndexedRecord): string {
+  if (record[SEARCH_BLOB] !== undefined) return record[SEARCH_BLOB]!;
+  const blob = buildSearchBlob(record);
+  record[SEARCH_BLOB] = blob;
+  return blob;
+}
+
 function matchesQuery(record: MemoryRecord, query: string): boolean {
   const needle = normalizeNeedle(query);
-  if (!needle) {
-    return true;
-  }
-
-  return record.summary.toLowerCase().includes(needle)
-    || record.tags.some((tag) => tag.toLowerCase().includes(needle))
-    || JSON.stringify(record.metadata ?? {}).toLowerCase().includes(needle);
+  if (!needle) return true;
+  return getSearchBlob(record as IndexedRecord).includes(needle);
 }
 
 function sortByNewest(records: MemoryRecord[]): MemoryRecord[] {
@@ -143,15 +158,33 @@ export class InMemoryMemoryStore implements MemoryStore {
   }
 
   async searchByScope(scope: MemoryRecord['scope'], query: string, limit = 10, scopeKey?: string): Promise<MemoryRecord[]> {
-    return sortByNewest([...this.store.values()].flat())
-      .filter((record) => matchesScope(record, scope, scopeKey))
-      .filter((record) => matchesQuery(record, query))
-      .slice(0, limit);
+    // Filter first (cheap scope check), then query (cached search blob).
+    // Previous implementation ran query filter over every record in every
+    // session regardless of scope, then flattened + stringified metadata
+    // per-record — catastrophic at 10 sessions × 100 memories.
+    const out: MemoryRecord[] = [];
+    for (const records of this.store.values()) {
+      for (const record of records) {
+        if (matchesScope(record, scope, scopeKey) && matchesQuery(record, query)) {
+          out.push(record);
+        }
+      }
+    }
+    return sortByNewest(out).slice(0, limit);
   }
 
   async write(record: MemoryRecord): Promise<void> {
-    const current = this.store.get(record.sessionId) ?? [];
-    this.store.set(record.sessionId, [...current, record]);
+    // Mutate the bucket in place (O(1) append) instead of `[...current, record]`
+    // which copied the entire array on every insert — the spread made write()
+    // O(n) and amortized session insertion O(n²).
+    const existing = this.store.get(record.sessionId);
+    // Pre-compute search blob once so later matchesQuery() calls are O(|needle|).
+    (record as IndexedRecord)[SEARCH_BLOB] = buildSearchBlob(record);
+    if (existing) {
+      existing.push(record);
+    } else {
+      this.store.set(record.sessionId, [record]);
+    }
   }
 
   async list(sessionId: string): Promise<MemoryRecord[]> {
@@ -159,9 +192,13 @@ export class InMemoryMemoryStore implements MemoryStore {
   }
 
   async listByScope(scope: MemoryRecord['scope'], limit = 50, scopeKey?: string): Promise<MemoryRecord[]> {
-    return sortByNewest([...this.store.values()].flat())
-      .filter((record) => matchesScope(record, scope, scopeKey))
-      .slice(0, limit);
+    const out: MemoryRecord[] = [];
+    for (const records of this.store.values()) {
+      for (const record of records) {
+        if (matchesScope(record, scope, scopeKey)) out.push(record);
+      }
+    }
+    return sortByNewest(out).slice(0, limit);
   }
 }
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/tools",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,12 +18,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.1",
-    "@crowclaw/gateway": "0.4.1",
-    "@crowclaw/memory": "0.4.1",
-    "@crowclaw/mcp": "0.4.1",
-    "@crowclaw/scheduler": "0.4.1",
-    "@crowclaw/storage": "0.4.1",
-    "@crowclaw/workspace": "0.4.1"
+    "@crowclaw/core": "0.4.2",
+    "@crowclaw/gateway": "0.4.2",
+    "@crowclaw/memory": "0.4.2",
+    "@crowclaw/mcp": "0.4.2",
+    "@crowclaw/scheduler": "0.4.2",
+    "@crowclaw/storage": "0.4.2",
+    "@crowclaw/workspace": "0.4.2"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/web",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/workspace",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",


### PR DESCRIPTION
## Summary

Third pass on the v0.4.0 deferred backlog. Closes the visible CF contract gaps, adds a real trusted-proxy allowlist for the auth throttle, and cuts the two biggest hot-path allocations.

## Security (HIGH)
- `CROWCLAW_TRUSTED_PROXIES=1.2.3.4,5.6.7.8` gates X-Forwarded-For trust. CLI HTTP wrapper injects the raw socket remote address as `x-crowclaw-remote-addr` (stripping any client-supplied value first so the header can't be forged); runtime only honors XFF when the remote is in the allowlist. Full CIDR support deferred (exact-match only for now).

## Cloudflare parity
- `/api/system/status.counts` shape matches Node (adds `bridgeProcesses`, `bridgeAliveProcesses` as `0`, drops non-Node `sessions` field).
- `/api/skills` returns `requiredTools` so Agent view tool chips render.
- `/api/presets` returns `activeAgent` / `activeToolset` / `activeMcp` (all `null` until CF persists the active selection — v0.4.3).

## Performance
- `InMemoryMemoryStore.write`: `O(n)` spread → `O(1)` push.
- Pre-indexed memory search via `Symbol`-keyed cached blob; `matchesQuery` is one `includes()` instead of `JSON.stringify(metadata).toLowerCase()` per record per search.
- `searchByScope` / `listByScope`: single-pass loop instead of `[...values()].flat()`.
- Checkpoint saves: dropped redundant `[...nextMessages]` spread across 5 call sites (the `structuredClone` inside `createCheckpoint` is the single copy source).

## Still deferred (v0.4.3+)
- CSP `style-src 'unsafe-inline'` → nonce
- `runtime-node/src/index.ts` 5400-line split
- Full CF endpoint parity (~25 routes still missing)
- `EmbeddingMemoryStore` linear scan
- CIDR (not just IP) support for trusted proxies
- Dashboard HTML parser-based nonce injection

## Test plan
- [x] `npm run preflight` (2161/2161 pass)
- [ ] Smoke: `CROWCLAW_TRUSTED_PROXIES=127.0.0.1 npm run dev`, XFF-spoofed request hits per-IP limit
- [ ] Smoke: write 1000 memories then search — latency should not scale linearly per search
- [ ] Smoke: CF deployment — system/status overview panel renders without undefined counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)