### PR TITLE
release: v0.4.3 — quickstart unblocked, CIDR proxies, capacity caps, README honest pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to CrowClaw will be documented in this file.
 > Releases v0.2.0 through v0.3.4 were tracked in GitHub Releases. See
 > https://github.com/subinium/hermes-agent-typescript/releases for details.
 
+## [0.4.3] — 2026-04-17 — Quickstart unblocked, CIDR proxies, capacity caps, README honest pass
+
+Last of the v0.4.x polish pass. The audit backlog has been drained of everything that moves the needle at this project's current user count (one). Future hardening queued in HISTORY for when demand actually lands.
+
+### Reliability
+- **`node packages/cli/dist/index.js` boots on plain Node.** The v0.4.0 audit flagged this as an `EXAMPLE_BROKEN`: `@cloudflare/sandbox` transitively imports `@cloudflare/containers` whose ESM index violates Node's strict-specifier resolution (`import './lib/container'` without `.js`). Loading it at `packages/sandbox-executor/src/index.ts:2` failed the whole CLI boot. Switched to `import type` + a top-level `try { await import('@cloudflare/sandbox') } catch {}` that caches `getSandbox` if it loaded, otherwise disables the Cloudflare sandbox path gracefully. Node users finally get a working `doctor`, `serve`, and interactive REPL.
+
+### Security
+- **CIDR-aware trusted-proxy allowlist.** `CROWCLAW_TRUSTED_PROXIES=10.0.0.0/24,fe80::/10,1.2.3.4` is now parsed into real IPv4 + IPv6 CIDR matchers (the v0.4.2 release shipped exact-IP match only). IPv4-mapped IPv6 (`::ffff:10.0.0.1`) is unwrapped to the IPv4 form, and the IPv6 zone-id suffix (`%eth0`) is stripped, so a CIDR like `10.0.0.0/24` matches clients that reach a dual-stack socket as either form.
+- **Dashboard nonce injection replaced with a tag-aware walker.** The regex `/<script(?![^>]*\bsrc\b)/g` had documented edge cases (`<scriptsrc=...>`, attributes straddling newlines, future contributors adding `<script data-foo>`). `injectScriptNonce()` now walks token-by-token, confirms the character after `<script` is a real boundary, and honors a real `src="..."` attribute (doesn't get confused by `srcset`).
+
+### Capacity
+- **`InMemoryCheckpointStore(maxCheckpoints?: number)` FIFO-evicts beyond the cap.** Default wiring in `createNodeRuntime` / `AgentSessionDurableObject` sets `maxCheckpoints: 1000`. Without this, a long-running server with `autoCheckpoint` on accumulates one checkpoint per iteration forever.
+- **`EmbeddingMemoryStore(maxVectors?: number)` default cap 10,000.** `EmbeddingIndex.add` returns the evicted id so the outer `recordCache` stays the same size as the index — previously the two drifted because only the index was bounded.
+
+### README honest pass
+- Hero rewritten to say what the framework actually is, not what it beats. Dropped the "Most agent frameworks…" framing and the comparison table (moved comparisons into an "Is this for you?" paragraph that names specific competitors and who to choose instead).
+- Quickstart fixed: `node packages/cli/dist/index.js` is no longer broken at startup; example queries updated to something you can actually run.
+- Added three concrete recipes ("Slack bot that learns from replies", "daily briefing cron", "replayable debug session") that correspond to features already shipping — you can build them today.
+- Status line is blunt: "Beta, single-maintainer, moving fast" instead of the prior breezy version.
+
+### Tests
+- 2161/2161 passing.
+
 ## [0.4.2] — 2026-04-17 — Cloudflare drift + trusted-proxy + memory / checkpoint perf
 
 Third pass on the v0.4.0 deferred backlog. Closes the three easy-to-see CF contract gaps from the contract audit, adds a real trusted-proxy allowlist for the auth throttle, and cuts the two biggest hot-path allocations (`InMemoryMemoryStore.write` and redundant checkpoint message clones).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="./docs/hero.png" alt="CrowClaw" width="720" />
   <h1 align="center">CrowClaw</h1>
   <p align="center">
-    <strong>A self-improving TypeScript agent framework that learns from every conversation.</strong>
+    <strong>TypeScript agent framework that learns from its own conversations.</strong>
   </p>
   <p align="center">
     <a href="https://www.npmjs.com/package/crowclaw"><img src="https://img.shields.io/npm/v/crowclaw?color=cb3837" alt="npm" /></a>
@@ -10,92 +10,85 @@
     <a href="#quickstart"><img src="https://img.shields.io/badge/node-%3E%3D22-blue.svg" alt="Node 22+" /></a>
     <a href="#project-structure"><img src="https://img.shields.io/badge/packages-19-purple.svg" alt="19 packages" /></a>
     <img src="https://img.shields.io/badge/tests-2161%20passed-brightgreen.svg" alt="Tests" />
+    <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/changelog-v0.4.3-blue.svg" alt="Changelog" /></a>
   </p>
 </p>
 
 ---
 
-> **Beta.** Core systems are functional and tested (2161 tests). APIs may change before 1.0 -- pin to minor versions for stability.
+> **Beta, single-maintainer, moving fast.** Core systems are tested (2161 tests) and the security/reliability surface has been through a five-agent cross-audit (see v0.4.x in [CHANGELOG.md](./CHANGELOG.md)). APIs may break between minor versions -- pin exactly.
 
-## Why CrowClaw
+## What it is
 
-Most agent frameworks give you a tool loop and stop there. CrowClaw closes the loop: your agent extracts reusable skills from conversations, publishes them, and injects them into future runs -- automatically. The more it works, the better it gets.
+A TypeScript agent loop with four things bolted together that most frameworks make you wire yourself:
 
-We [studied 30+ agent frameworks](https://github.com/subinium/awesome-agent-frameworks), identified what each one does best, and built one that combines them:
+1. **A real multi-turn tool loop** (50+ tools, retries, fallbacks, approval gates, checkpoint/rollback).
+2. **A learning loop** -- the agent extracts skills from completed conversations, publishes them, injects them into future runs.
+3. **Inbound webhook normalizers for 8 messaging platforms** (Telegram, Discord, Slack, WhatsApp, Signal, Email, Matrix, SMS) and outbound senders for 6.
+4. **A live dashboard + CLI REPL + scheduled execution** sitting on top of the same runtime, on Node or Cloudflare Workers.
 
-| What you need | CrowClaw | Typical frameworks |
-|---|---|---|
-| **Learning from conversations** | Auto-extracts skills, publishes to registry, injects into future prompts | Manual prompt engineering |
-| **Multi-platform delivery** | 8 platforms (Telegram, Discord, Slack, WhatsApp, Signal, Email, Matrix, SMS) with webhook normalization, rate limiting, retry | Usually 1-2, or BYO |
-| **Operator surface** | Web dashboard, CLI REPL, scheduled execution, batch processing, checkpoint/rollback | API-only or minimal UI |
-| **Production hardening** | SSRF protection, CSP nonce, prompt injection scanning, auth rate limiting, session mutex, graceful shutdown | Security as afterthought |
-| **Runs anywhere** | Node.js, Cloudflare Workers, CLI, Docker | Usually single runtime |
+It started as a TypeScript port of [Hermes Agent](https://github.com/NousResearch/hermes-agent), then absorbed patterns from [OpenClaw](https://docs.openclaw.ai), [NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit), and a [survey of ~30 other frameworks](https://github.com/subinium/awesome-agent-frameworks). Credit, influences, and the design-heritage table are at the bottom.
 
-<details>
-<summary><strong>How CrowClaw compares to specific frameworks</strong></summary>
+### Is this for you?
 
-- **vs LangChain/LlamaIndex**: CrowClaw is opinionated where they are flexible. You get a working agent with 50+ tools, a dashboard, and a learning loop out of the box -- not a toolkit to assemble one.
-- **vs Vercel AI SDK**: Vercel focuses on frontend AI UX. CrowClaw focuses on backend agent autonomy -- scheduled tasks, multi-turn tool loops, cross-platform delivery.
-- **vs CrewAI/AutoGen**: Multi-agent orchestration frameworks. CrowClaw is a single-agent framework with delegation, designed for depth (learning, checkpoints, security) over breadth (agent graphs).
-- **vs OpenClaw/Hermes Agent**: CrowClaw is a direct evolution. TypeScript-native, runs on Cloudflare Workers, adds security hardening, batch processing, and checkpoint/rollback that the originals don't have.
-
-</details>
-
-## The Story
-
-CrowClaw started as an effort to bring [Hermes Agent](https://github.com/NousResearch/hermes-agent) (Python) to Cloudflare Workers. Porting it to TypeScript opened up a chance to rethink the architecture -- so we [studied dozens of agent frameworks](https://github.com/subinium/awesome-agent-frameworks), distilled the best patterns from each, and built a framework that actually closes the loop: your agent gets better every time it completes a task.
-
-It runs a multi-turn tool loop, learns skills from conversations, schedules autonomous tasks, and delivers results across 8 messaging platforms.
+- **Yes, if** you want a single opinionated runtime that already speaks HTTP, MCP, Slack, and cron; and you want the agent to get measurably better at repeated tasks without you hand-writing prompts.
+- **Probably not, if** you want a lightweight SDK to drop into an existing Next.js app -- [Vercel AI SDK](https://sdk.vercel.ai) is closer. Or if you need multi-agent graphs -- [CrewAI](https://www.crewai.com) or [AutoGen](https://microsoft.github.io/autogen/) are closer.
 
 ## Quickstart
 
-**Requirements**: Node.js >= 22
+**Requirements**: Node.js >= 22.
 
 ```bash
 git clone https://github.com/subinium/crowclaw.git
 cd crowclaw
-npm install
-npm run build
+npm install && npm run build
 
-# Configure an LLM provider
-cp .env.example .env
-# Set OPENAI_API_KEY or ANTHROPIC_API_KEY in .env
+# Provider (at least one)
+export OPENAI_API_KEY=sk-...
+# or: export ANTHROPIC_API_KEY=sk-ant-...
 
-# Start the interactive CLI
+# Interactive REPL (talks to the same runtime the dashboard uses)
 node packages/cli/dist/index.js
 ```
 
 ```
-crowclaw> hello!
-[cli-1] CrowClaw received: hello!
-
-crowclaw> /tools
-crowclaw> /help
+crowclaw> /doctor       # show configured provider, tool count, security state
+crowclaw> /tools        # list registered tools
+crowclaw> what day is it
+CrowClaw: Today is 2026-04-17.
+crowclaw> fetch https://news.ycombinator.com and summarize the top 3 stories
+...
 ```
 
-### API Server
+### HTTP server + dashboard
 
 ```bash
-npm run dev   # starts on :8787
+# Start a local HTTP server + the Lit dashboard on :3117
+node packages/cli/dist/index.js serve
 
-curl -X POST http://localhost:8787/api/sessions/demo/message \
+# Dashboard: http://localhost:3117/
+# API example:
+curl -X POST http://localhost:3117/api/sessions/demo/message \
   -H 'content-type: application/json' \
   -d '{"userMessage": "What can you do?"}'
-
-# Response:
-# { "ok": true, "response": "I can help with...", "sessionId": "demo" }
 ```
 
-### Docker
+Bind to a non-localhost interface and the runtime refuses to serve `/api/*` until `CROWCLAW_DASHBOARD_TOKEN` is set — the dashboard uses an HttpOnly cookie derived from that token. See [Security](#security) below.
 
-```bash
-docker build -t crowclaw .
-docker run -p 8787:8787 -e OPENAI_API_KEY=sk-... crowclaw
-```
+### What you can actually build
 
-## End-to-End Example
+Three recipes that exist today, as much to prove the agent-loop surface as anything:
 
-A complete agent that uses tools, matches skills, and responds:
+1. **A Slack bot that learns from its replies.**
+   Configure a Slack bot (signing secret in `.env`), point its Events URL at `https://<your-host>/webhooks/slack`, and every DM becomes a `SessionState` with its own scheduler context. After a task finishes, `LearningPipeline.autoCapture` extracts a skill draft from the conversation — approve it from the dashboard, and the next relevant DM gets that skill auto-injected.
+2. **A daily briefing cron.** `createScheduledAgentJob({ schedule: '0 9 * * *', task: 'Summarize yesterday\\'s GitHub issues in #INGEST', deliverTo: { platform: 'telegram', config: { botToken, chatId } } })` and the scheduler runs it against your chosen provider + tool registry at 09:00. Output goes out the same gateway as your inbound Slack.
+3. **A replayable debug session.** Run an agent task, checkpoint-per-iteration is on by default; if the 7th step blew up, `restoreFromCheckpoint` grabs step 6's state + `toolResults` + `loopState`, tweak the config, and `createReplaySession` starts a fresh session from that point — useful for prompt-engineering regressions.
+
+None of these require a separate task queue, webhook normalizer, or scheduler — they're the same runtime.
+
+## Minimal programmatic example
+
+If you're embedding the runtime in your own Node process rather than using the CLI:
 
 ```typescript
 import { AgentLoop } from '@crowclaw/core'
@@ -611,7 +604,7 @@ Before opening a PR:
 
 ## Design Heritage
 
-CrowClaw is built on patterns distilled from studying dozens of agent frameworks. See [awesome-agent-frameworks](https://github.com/subinium/awesome-agent-frameworks) for the full survey. Below are the primary influences and what we adopted from each.
+The interesting patterns came from other people's projects. Below is who-from-where. See [awesome-agent-frameworks](https://github.com/subinium/awesome-agent-frameworks) for the full survey.
 
 ### Hermes Agent (Python, NousResearch)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowclaw",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "A self-improving TypeScript agent framework that learns from every conversation.",
   "bin": {

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/acp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.2"
+    "@crowclaw/core": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -22,6 +22,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/plugins": "0.4.2"
+    "@crowclaw/plugins": "0.4.3"
   }
 }

--- a/packages/core/src/checkpoint.ts
+++ b/packages/core/src/checkpoint.ts
@@ -38,11 +38,30 @@ export interface CheckpointStore {
   deleteBySession(sessionId: string): Promise<number>;
 }
 
+export interface InMemoryCheckpointStoreOptions {
+  /** Cap total checkpoints held in memory. FIFO eviction by insertion order
+   *  keeps the newest N. Unbounded by default to preserve prior behavior,
+   *  but production callers should always set this — a long-running server
+   *  with autoCheckpoint on accumulates one checkpoint per iteration forever. */
+  maxCheckpoints?: number;
+}
+
 export class InMemoryCheckpointStore implements CheckpointStore {
   private readonly store = new Map<string, SessionCheckpoint>();
+  private readonly maxCheckpoints: number | undefined;
+
+  constructor(options?: InMemoryCheckpointStoreOptions) {
+    this.maxCheckpoints = options?.maxCheckpoints;
+  }
 
   async save(checkpoint: SessionCheckpoint): Promise<void> {
     this.store.set(checkpoint.id, structuredClone(checkpoint));
+    // FIFO eviction: Map iteration order preserves insertion order, so
+    // the first entry is always the oldest.
+    if (this.maxCheckpoints !== undefined && this.store.size > this.maxCheckpoints) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) this.store.delete(oldest);
+    }
   }
 
   async get(id: string): Promise<SessionCheckpoint | null> {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/gateway",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/learning",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,6 +18,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.2"
+    "@crowclaw/core": "0.4.3"
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/mcp-server",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.2"
+    "@crowclaw/core": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/mcp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/sandbox-executor": "0.4.2"
+    "@crowclaw/sandbox-executor": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/memory",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.2",
-    "@crowclaw/storage": "0.4.2"
+    "@crowclaw/core": "0.4.3",
+    "@crowclaw/storage": "0.4.3"
   }
 }

--- a/packages/memory/src/embedding-store.ts
+++ b/packages/memory/src/embedding-store.ts
@@ -10,6 +10,11 @@ export interface EmbeddingMemoryStoreOptions {
   embeddingProvider: EmbeddingProvider;
   similarityThreshold?: number;
   deduplicationThreshold?: number;
+  /** Cap total vectors held in the in-memory index. FIFO eviction beyond the
+   *  cap (oldest insertion order). Without a cap, the linear-scan `search()`
+   *  crosses 100ms around 10k entries and grows without bound. Defaults to
+   *  10_000 — pair with a real ANN backend for anything higher. */
+  maxVectors?: number;
 }
 
 /** Cosine similarity between two vectors. Returns 0 if either vector has zero magnitude. */
@@ -39,9 +44,24 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 /** Simple in-memory embedding index for vector similarity search. */
 export class EmbeddingIndex {
   private readonly vectors = new Map<string, number[]>();
+  private readonly maxVectors: number | undefined;
 
-  add(id: string, vector: number[]): void {
+  constructor(options?: { maxVectors?: number }) {
+    this.maxVectors = options?.maxVectors;
+  }
+
+  /** Returns the id of the evicted record, if eviction fired. */
+  add(id: string, vector: number[]): string | null {
     this.vectors.set(id, vector);
+    // FIFO eviction once capped — Map preserves insertion order.
+    if (this.maxVectors !== undefined && this.vectors.size > this.maxVectors) {
+      const oldest = this.vectors.keys().next().value;
+      if (oldest !== undefined && oldest !== id) {
+        this.vectors.delete(oldest);
+        return oldest;
+      }
+    }
+    return null;
   }
 
   remove(id: string): void {
@@ -88,15 +108,18 @@ export class EmbeddingMemoryStore implements MemoryStore {
   private readonly embeddingProvider: EmbeddingProvider;
   private readonly similarityThreshold: number;
   private readonly deduplicationThreshold: number;
-  private readonly index = new EmbeddingIndex();
+  private readonly index: EmbeddingIndex;
   /** Maps record id -> record for dedup lookups. */
   private readonly recordCache = new Map<string, MemoryRecord>();
+  private readonly maxVectors: number;
 
   constructor(options: EmbeddingMemoryStoreOptions) {
     this.baseStore = options.baseStore;
     this.embeddingProvider = options.embeddingProvider;
     this.similarityThreshold = options.similarityThreshold ?? 0.7;
     this.deduplicationThreshold = options.deduplicationThreshold ?? 0.95;
+    this.maxVectors = options.maxVectors ?? 10_000;
+    this.index = new EmbeddingIndex({ maxVectors: this.maxVectors });
   }
 
   async write(record: MemoryRecord): Promise<void> {
@@ -127,8 +150,10 @@ export class EmbeddingMemoryStore implements MemoryStore {
       }
     }
 
-    // No duplicate — insert as new
-    this.index.add(record.id, embedding);
+    // No duplicate — insert as new. Prune recordCache alongside the index
+    // so the two stay the same size (otherwise recordCache leaks past maxVectors).
+    const evicted = this.index.add(record.id, embedding);
+    if (evicted) this.recordCache.delete(evicted);
     this.recordCache.set(record.id, record);
     await this.baseStore.write(record);
   }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/plugins",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/providers",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,6 +18,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.2"
+    "@crowclaw/core": "0.4.3"
   }
 }

--- a/packages/runtime-cloudflare/package.json
+++ b/packages/runtime-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/runtime-cloudflare",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -19,18 +19,18 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.8.9",
-    "@crowclaw/core": "0.4.2",
-    "@crowclaw/memory": "0.4.2",
-    "@crowclaw/providers": "0.4.2",
-    "@crowclaw/sandbox-executor": "0.4.2",
-    "@crowclaw/shared": "0.4.2",
-    "@crowclaw/storage": "0.4.2",
-    "@crowclaw/tools": "0.4.2",
-    "@crowclaw/gateway": "0.4.2",
-    "@crowclaw/workspace": "0.4.2",
-    "@crowclaw/learning": "0.4.2",
-    "@crowclaw/mcp": "0.4.2",
-    "@crowclaw/scheduler": "0.4.2",
-    "@crowclaw/plugins": "0.4.2"
+    "@crowclaw/core": "0.4.3",
+    "@crowclaw/memory": "0.4.3",
+    "@crowclaw/providers": "0.4.3",
+    "@crowclaw/sandbox-executor": "0.4.3",
+    "@crowclaw/shared": "0.4.3",
+    "@crowclaw/storage": "0.4.3",
+    "@crowclaw/tools": "0.4.3",
+    "@crowclaw/gateway": "0.4.3",
+    "@crowclaw/workspace": "0.4.3",
+    "@crowclaw/learning": "0.4.3",
+    "@crowclaw/mcp": "0.4.3",
+    "@crowclaw/scheduler": "0.4.3",
+    "@crowclaw/plugins": "0.4.3"
   }
 }

--- a/packages/runtime-cloudflare/src/agent-do.ts
+++ b/packages/runtime-cloudflare/src/agent-do.ts
@@ -139,7 +139,7 @@ export class AgentSessionDurableObject {
   private readonly memoryService: MemoryService;
   private readonly workspaceStore = new InMemoryWorkspaceStore();
   private readonly schedulerStore = new InMemorySchedulerStore();
-  private readonly checkpointStore = new InMemoryCheckpointStore();
+  private readonly checkpointStore = new InMemoryCheckpointStore({ maxCheckpoints: 1000 });
   private readonly skillStore = new InMemorySkillStore();
   private readonly learning = new LearningPipeline(this.skillStore);
   private readonly mcpClient: McpClient;

--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/runtime-node",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -34,18 +34,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/acp": "0.4.2",
-    "@crowclaw/core": "0.4.2",
-    "@crowclaw/gateway": "0.4.2",
-    "@crowclaw/learning": "0.4.2",
-    "@crowclaw/mcp": "0.4.2",
-    "@crowclaw/mcp-server": "0.4.2",
-    "@crowclaw/memory": "0.4.2",
-    "@crowclaw/plugins": "0.4.2",
-    "@crowclaw/providers": "0.4.2",
-    "@crowclaw/scheduler": "0.4.2",
-    "@crowclaw/storage": "0.4.2",
-    "@crowclaw/tools": "0.4.2",
-    "@crowclaw/workspace": "0.4.2"
+    "@crowclaw/acp": "0.4.3",
+    "@crowclaw/core": "0.4.3",
+    "@crowclaw/gateway": "0.4.3",
+    "@crowclaw/learning": "0.4.3",
+    "@crowclaw/mcp": "0.4.3",
+    "@crowclaw/mcp-server": "0.4.3",
+    "@crowclaw/memory": "0.4.3",
+    "@crowclaw/plugins": "0.4.3",
+    "@crowclaw/providers": "0.4.3",
+    "@crowclaw/scheduler": "0.4.3",
+    "@crowclaw/storage": "0.4.3",
+    "@crowclaw/tools": "0.4.3",
+    "@crowclaw/workspace": "0.4.3"
   }
 }

--- a/packages/runtime-node/src/index.ts
+++ b/packages/runtime-node/src/index.ts
@@ -693,6 +693,104 @@ function renderBrowserClickRefResult(url: string, ref: string) {
 // Rate Limiter — simple in-memory, per-key, sliding-window
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// CIDR matching for trusted-proxy allowlist
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a predicate that matches an IP (already normalized) against a CIDR
+ * or single-IP entry. IPv4 entries compare as 32-bit integers; IPv6 as a
+ * pair of 64-bit integers. Returns null for unparseable input.
+ *
+ * Accepts:
+ *   - `10.0.0.1`               (single IPv4, equivalent to /32)
+ *   - `10.0.0.0/24`            (IPv4 CIDR)
+ *   - `::1`                    (single IPv6, equivalent to /128)
+ *   - `fe80::/10`              (IPv6 CIDR)
+ */
+type CidrMatcher = (ip: string) => boolean;
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  let out = 0;
+  for (const part of parts) {
+    const n = Number(part);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+    out = (out << 8) | n;
+  }
+  return out >>> 0;
+}
+
+function ipv6ToBigInt(ip: string): bigint | null {
+  // Handle IPv4-mapped form ::ffff:1.2.3.4 by converting the trailing dotted quad.
+  const dotIdx = ip.lastIndexOf('.');
+  let normalized = ip;
+  if (dotIdx !== -1) {
+    const v4Start = ip.lastIndexOf(':', dotIdx);
+    if (v4Start === -1) return null;
+    const v4 = ipv4ToInt(ip.slice(v4Start + 1));
+    if (v4 === null) return null;
+    normalized = `${ip.slice(0, v4Start + 1)}${(v4 >>> 16).toString(16)}:${(v4 & 0xffff).toString(16)}`;
+  }
+  // Expand `::` into enough zero groups to reach 8 total.
+  const parts = normalized.split('::');
+  if (parts.length > 2) return null;
+  const leading = parts[0] ? parts[0].split(':') : [];
+  const trailing = parts[1] ? parts[1].split(':') : [];
+  const fill = 8 - leading.length - trailing.length;
+  if (fill < 0) return null;
+  const groups = [...leading, ...Array(fill).fill('0'), ...trailing];
+  if (groups.length !== 8) return null;
+  let out = 0n;
+  for (const g of groups) {
+    const n = parseInt(g || '0', 16);
+    if (Number.isNaN(n) || n < 0 || n > 0xffff) return null;
+    out = (out << 16n) | BigInt(n);
+  }
+  return out;
+}
+
+function parseCidrMatcher(entry: string): CidrMatcher | null {
+  const [addr, bitsRaw] = entry.split('/');
+  if (!addr) return null;
+  // IPv4
+  if (!addr.includes(':')) {
+    const base = ipv4ToInt(addr);
+    if (base === null) return null;
+    const bits = bitsRaw === undefined ? 32 : Number(bitsRaw);
+    if (!Number.isInteger(bits) || bits < 0 || bits > 32) return null;
+    const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+    const baseMasked = (base & mask) >>> 0;
+    return (ip: string) => {
+      const ipInt = ipv4ToInt(ip);
+      if (ipInt === null) return false;
+      return ((ipInt & mask) >>> 0) === baseMasked;
+    };
+  }
+  // IPv6
+  const base = ipv6ToBigInt(addr);
+  if (base === null) return null;
+  const bits = bitsRaw === undefined ? 128 : Number(bitsRaw);
+  if (!Number.isInteger(bits) || bits < 0 || bits > 128) return null;
+  const mask = bits === 0 ? 0n : ((1n << BigInt(bits)) - 1n) << BigInt(128 - bits);
+  const baseMasked = base & mask;
+  return (ip: string) => {
+    const ipInt = ipv6ToBigInt(ip);
+    if (ipInt === null) return false;
+    return (ipInt & mask) === baseMasked;
+  };
+}
+
+/** Strip IPv6 zone id (`%eth0`) and unwrap IPv4-mapped `::ffff:1.2.3.4` to `1.2.3.4`
+ *  so a CIDR like `10.0.0.0/24` matches clients that reach the socket as the
+ *  IPv4-mapped form on dual-stack sockets. */
+function normalizeIp(ip: string): string {
+  const noZone = ip.split('%')[0]!;
+  const mapped = noZone.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  return mapped ? mapped[1]! : noZone;
+}
+
 class RateLimiter {
   private requests = new Map<string, number[]>();
   private readonly maxKeys: number;
@@ -738,6 +836,50 @@ const API_CSP = "default-src 'none'; frame-ancestors 'none'";
 /** Generate a cryptographic nonce for CSP. */
 function generateNonce(): string {
   return randomBytes(16).toString('base64');
+}
+
+/**
+ * Inject a CSP nonce into every inline `<script>` tag in `html`. Replaces the
+ * v0.3.6-era regex `/<script(?![^>]*\bsrc\b)/g` which had known edge cases:
+ *   - `<scriptsrc=...>` (no space) matched incorrectly as a "no src" tag.
+ *   - Contributors adding a `src=""` (empty src) would get a nonce injected.
+ * This walks the string tag-by-tag, checks the character after `<script` is a
+ * real boundary (space/tab/newline/`>`), and honors any real `src="..."`.
+ */
+function injectScriptNonce(html: string, nonce: string): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < html.length) {
+    const next = html.indexOf('<script', i);
+    if (next === -1) {
+      out.push(html.slice(i));
+      break;
+    }
+    out.push(html.slice(i, next));
+    const afterScript = next + '<script'.length;
+    const nextChar = html[afterScript];
+    // `<scriptxxx` — not a real <script> tag, emit verbatim and keep scanning.
+    if (nextChar !== ' ' && nextChar !== '>' && nextChar !== '\t' && nextChar !== '\n' && nextChar !== '/') {
+      out.push(html.slice(next, afterScript));
+      i = afterScript;
+      continue;
+    }
+    const tagEnd = html.indexOf('>', afterScript);
+    if (tagEnd === -1) {
+      out.push(html.slice(next));
+      break;
+    }
+    const attrs = html.slice(afterScript, tagEnd);
+    // Tags with `src=...` load an external script; CSP allows them via
+    // `script-src https://cdnjs.cloudflare.com`. Inline (no src) needs a nonce.
+    if (/\bsrc\s*=/.test(attrs)) {
+      out.push(html.slice(next, tagEnd + 1));
+    } else {
+      out.push(`<script nonce="${nonce}"${attrs}>`);
+    }
+    i = tagEnd + 1;
+  }
+  return out.join('');
 }
 
 /** CSP for dashboard pages (nonce-based script-src, unsafe-inline for styles). */
@@ -1580,7 +1722,10 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
     }, { status: 403 });
   }
 
-  const checkpointStore = new InMemoryCheckpointStore();
+  // Cap at 1000 checkpoints across all sessions. With autoCheckpoint on,
+  // a long-running server accumulates one per iteration forever — the cap
+  // keeps in-memory growth bounded. FIFO evicts the oldest.
+  const checkpointStore = new InMemoryCheckpointStore({ maxCheckpoints: 1000 });
 
   // Delivery function — routes scheduled job results to gateway platforms
   const deliverToGateway: DeliveryFn = async (target: DeliveryTarget, content: string) => {
@@ -1758,14 +1903,14 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       // but the global 60/min auth backstop from v0.4.1 still applies.
       const trustedProxiesRaw = (globalThis as unknown as { process?: { env?: Record<string, string | undefined> } })
         .process?.env?.CROWCLAW_TRUSTED_PROXIES;
-      const trustedProxies = trustedProxiesRaw
-        ? new Set(trustedProxiesRaw.split(',').map((s) => s.trim()).filter(Boolean))
+      const trustedProxyMatchers = trustedProxiesRaw
+        ? trustedProxiesRaw.split(',').map((s) => s.trim()).filter(Boolean).map(parseCidrMatcher).filter((m): m is CidrMatcher => m !== null)
         : null;
       const getClientIp = (req: Request): string => {
-        const remoteAddr = req.headers.get('x-crowclaw-remote-addr') ?? '127.0.0.1';
+        const remoteAddr = normalizeIp(req.headers.get('x-crowclaw-remote-addr') ?? '127.0.0.1');
         if (configStore.getTrustProxy() || options.trustProxy) {
-          if (trustedProxies && !trustedProxies.has(remoteAddr)) {
-            // Remote addr is not in the allowlist — don't trust the header.
+          if (trustedProxyMatchers && !trustedProxyMatchers.some((m) => m(remoteAddr))) {
+            // Remote addr doesn't match any allowlist entry (IP or CIDR).
             return remoteAddr;
           }
           return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
@@ -1949,8 +2094,9 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/dashboard')) {
         const { DASHBOARD_HTML } = await import('@crowclaw/web');
         const nonce = generateNonce();
-        // Inject nonce into inline <script> tags for CSP compliance
-        const nonceHtml = DASHBOARD_HTML.replace(/<script(?![^>]*\bsrc\b)/g, `<script nonce="${nonce}"`);
+        // Inject nonce via a tag-aware walker (not regex — see comment on
+        // injectScriptNonce for the edge cases it handles).
+        const nonceHtml = injectScriptNonce(DASHBOARD_HTML, nonce);
         return new Response(nonceHtml, {
           headers: {
             'content-type': 'text/html; charset=utf-8',

--- a/packages/sandbox-executor/package.json
+++ b/packages/sandbox-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/sandbox-executor",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.8.9",
-    "@crowclaw/core": "0.4.2",
-    "@crowclaw/tools": "0.4.2"
+    "@crowclaw/core": "0.4.3",
+    "@crowclaw/tools": "0.4.3"
   }
 }

--- a/packages/sandbox-executor/src/index.ts
+++ b/packages/sandbox-executor/src/index.ts
@@ -1,5 +1,23 @@
 /// <reference types="node" />
-import { getSandbox, type Sandbox as CloudflareSandbox } from '@cloudflare/sandbox';
+// Type-only import: the actual `getSandbox` value comes from the `_getSandboxFn`
+// below, which is loaded via top-level dynamic import with a try/catch so Node
+// deployments don't fail at module-eval time. `@cloudflare/sandbox` transitively
+// loads `@cloudflare/containers`, which ships an ESM index that violates Node's
+// strict specifier resolution (imports `./lib/container` without `.js`).
+import type { Sandbox as CloudflareSandbox } from '@cloudflare/sandbox';
+
+type GetSandboxFn = (ns: unknown, id: string) => CloudflareSandbox;
+let _getSandboxFn: GetSandboxFn | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const mod = await import('@cloudflare/sandbox');
+  _getSandboxFn = mod.getSandbox as unknown as GetSandboxFn;
+} catch {
+  // Cloudflare sandbox not loadable in this runtime (plain Node, etc.).
+  // Sandbox-dependent tool calls will return null and fall through to the
+  // local-process path or a runtime-level 400, which is the correct behavior.
+  _getSandboxFn = null;
+}
 import type { ToolDefinition, ToolExecutionContext, ToolExecutionResult } from '@crowclaw/core';
 import type { ToolRegistry } from '@crowclaw/tools';
 import { spawn, type ChildProcess } from 'node:child_process';
@@ -486,9 +504,11 @@ function resolveSandbox(context: ToolExecutionContext): CloudflareSandbox | null
   if (!env.Sandbox) {
     return null;
   }
-
+  if (!_getSandboxFn) {
+    return null;
+  }
   const sandboxId = context.workspaceId ?? context.sessionId;
-  return getSandbox(env.Sandbox as never, sandboxId) as CloudflareSandbox;
+  return _getSandboxFn(env.Sandbox as never, sandboxId);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/scheduler",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/shared",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/storage",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,8 +18,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.2",
-    "@crowclaw/shared": "0.4.2"
+    "@crowclaw/core": "0.4.3",
+    "@crowclaw/shared": "0.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/tools",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,12 +18,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.4.2",
-    "@crowclaw/gateway": "0.4.2",
-    "@crowclaw/memory": "0.4.2",
-    "@crowclaw/mcp": "0.4.2",
-    "@crowclaw/scheduler": "0.4.2",
-    "@crowclaw/storage": "0.4.2",
-    "@crowclaw/workspace": "0.4.2"
+    "@crowclaw/core": "0.4.3",
+    "@crowclaw/gateway": "0.4.3",
+    "@crowclaw/memory": "0.4.3",
+    "@crowclaw/mcp": "0.4.3",
+    "@crowclaw/scheduler": "0.4.3",
+    "@crowclaw/storage": "0.4.3",
+    "@crowclaw/workspace": "0.4.3"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/web",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/workspace",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",


### PR DESCRIPTION
Last of the v0.4.x polish. Audit backlog drained of everything that moves the needle at this project's current user count.

## Reliability
- **`node packages/cli/dist/index.js` boots on plain Node.** The v0.4.0 audit `EXAMPLE_BROKEN`: `@cloudflare/sandbox` → `@cloudflare/containers` whose ESM index violates Node's strict-specifier resolution. `sandbox-executor` now loads it via top-level `try { await import(...) } catch {}`, caches `getSandbox` if resolved, disables the CF sandbox path gracefully otherwise. `doctor`, `serve`, REPL all work.

## Security
- **CIDR-aware `CROWCLAW_TRUSTED_PROXIES`**: real IPv4 + IPv6 CIDR matchers, IPv4-mapped IPv6 unwrap, IPv6 zone-id strip. v0.4.2 shipped exact-IP only.
- **`injectScriptNonce` tag-aware walker** replaces the `<script(?![^>]*\bsrc\b)` regex that had known edge cases.

## Capacity
- `InMemoryCheckpointStore(maxCheckpoints?)` FIFO-evicts. Runtime default 1000.
- `EmbeddingMemoryStore(maxVectors?)` default 10_000; `EmbeddingIndex.add` returns evicted id so `recordCache` doesn't drift past the cap.

## README honest pass
- Hero rewritten to say what the framework is, not what it beats.
- Dropped "most agent frameworks…" framing + the comparison table; replaced with an "Is this for you?" paragraph that names specific alternatives.
- Quickstart uses the command that actually works (no more `ERR_MODULE_NOT_FOUND`).
- Three concrete recipes ("Slack bot that learns", "daily briefing cron", "replayable debug session") — all buildable with current features.
- Status line: "Beta, single-maintainer, moving fast."

## Tests
2161/2161 passing.

## This closes the v0.4.x arc
v0.3.6 → v0.4.3 covered: 6 BLOCKER + 13 CRITICAL + 17 HIGH audit findings, test count unchanged at 2161, nine merged PRs. Remaining items (CSP nonce for styles, 5400-line `runtime-node/src/index.ts` split, full CF endpoint parity, `EmbeddingMemoryStore` ANN) are defer-until-demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)