### PR TITLE
release: v0.6.1 — 26-issue follow-up sweep (shutdown leaks, body cap, gateway poison + WS auth, layering)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to CrowClaw will be documented in this file.
 > Releases v0.2.0 through v0.3.4 were tracked in GitHub Releases. See
 > https://github.com/subinium/hermes-agent-typescript/releases for details.
 
+## [0.6.1] — 2026-04-28 — 26-issue follow-up sweep: shutdown leaks, body cap, gateway poison + WS auth limit, layering fix
+
+Follow-up sweep on the v0.6.0 release. Triaged the 89 issues that v0.6.0 left open and processed every non-breaking item with another **8-way parallel agent execution** round. Of the 89 open: ~40 were closed retroactively (work was actually shipped in v0.6.0 but commit-message close keywords didn't match the GH issue numbers exactly), ~26 implemented in this release, ~23 remain (breaking changes / architectural scope deferred to v0.7).
+
+- **7 commits**, ~50 files changed, ~+5,500 / -340 lines
+- **2,532 / 2,532 tests passing** (up from 2,421 — **111 new tests**)
+- 6 new test files: `v06_1-runtime-node-shutdown` (27), `v06_1-gateway` (21), `v06_1-tools-memory` (16), `v06_1-mcp-providers-acp` (24), `v06_1-core-plugins-layering` (12), `do-idempotency-store` (12), plus glossary doc
+
+### Reliability (CRITICAL)
+- **Runtime-node shutdown closes all v0.6.0 leaks** (#115 #116 #118 #119 #120 #123 #124 #128 #156). v0.6.0 added the `WebSocketManager.stop()` API but no caller; v0.6.1 wires it into `shutdown()` alongside `pruneDeadBridgeProcesses` (only collects records with `exitedAt`; preserves spawn-error records for operator visibility), `unsubscribeHeartbeatTracker`, `clearInterval(contextRefresh)`, `GatewayDebouncer.flush()`, and child-handle `removeAllListeners + null`. RateLimiter eviction off-by-one fixed (forward-walk that always frees one slot and never evicts the just-inserted key). Vestigial `as unknown as` casts on `mcpClient` dropped at 7 of 9 sites. (`packages/runtime-node/src/index.ts`, `bridge-process.ts`.)
+- **1 MiB body size cap on POST/PUT/PATCH/DELETE** (#128). New `checkContentLengthCap` (header gate) + `readJsonWithSizeCap` (streaming + chunked-defense) helpers. Global precheck rejects oversized requests with HTTP 413 before buffering; unauthenticated `/api/auth/verify` reads with the streaming-safe parser. Logs every rejection with client IP for observability.
+- **WS auth rate-limit + exponential backoff bans** (#69). `WsAuthRateLimiter` from `@crowclaw/gateway`: per-IP attempt cap (5/min), failed-auth backoff bans starting at 5min, doubling, capped at 1h. Applied at `runtime-node` `/ws` upgrade before reading credentials. Successful auth clears the IP. (OpenClaw CVE-2026-32025 parity.)
+- **Gateway dedupe poisoning after visible progress** (#78). `GatewayIdempotencyStore` extended with `poisonAfterProgress(key)` and tri-state `claim()` returning `'fresh' | 'duplicate' | 'poisoned'`. After a tool side-effect or streamed token, retries return `409 poisoned` instead of silently re-running. (OpenClaw v2026.4.25 issues #69303 / #58549.)
+- **MemoryManager.shutdown passes session transcript** (#85). New `shutdown(sessionId, messages)` fans the live transcript out to every provider's optional `onSessionEnd`; previously call sites passed `[]`, silently disabling dream-memory live capture. Per-provider failures isolated via `SessionEndResult[]`. (Hermes PR #16571 parity.)
+- **Concurrent approval callback propagation** (#86). `ToolRegistry.execute` snapshots `context.approval` into a per-dispatch symbol slot before calling `tool.execute`. Concurrent `Promise.all` workers see a stable approval reference even when the parent context is mutated mid-flight. (Hermes PR #16574 parity.)
+- **read_file dedup-stub escalation** (#88). `workspace.read` tracks per-session per-path read counts; after `WORKSPACE_READ_DEDUP_LIMIT=3` repeats, returns BLOCKED with `metadata['tool:blocked_dedup']=true`. Adds `resetWorkspaceReadDedup` for host session-end hooks. (Hermes PR #16382 parity.)
+
+### Reliability / DX (WARNING)
+- **MCP idle session TTL + stdio auto-reconnect with backoff** (#80, #103). `McpClient.sessionIdleTtlMs` + `sweepIfIdle` / `dispose` / `isIdle` helpers; `MultiServerMcpManager.sweepIdle` / `disposeAll`. Stdio transport `autoReconnect: true` (default) with 1s/2s/4s backoff and max 3 attempts; `disconnect()` cancels pending timer.
+- **Telegram update batches concurrent with p-limit(3)** (#109). Per-update logic extracted to `handleTelegramUpdate`; 10-message burst now runs in ~4 waves instead of serially.
+- **Telegram bot tokens scrubbed from error paths** (#134). `bot<digits>:<token>` → `bot[REDACTED]` before storing in `GatewayStatus` or returning via `/api/gateway/status`. Applied to `telegramGetMe`, `telegramGetUpdates`, `startTelegram` error path, and the poll-loop status update.
+- **AcpServer `tools/list` connects to optional registry** (#148). Constructor accepts `tools?: () => AcpToolInfo[]` callback; returns `{ tools, available: true }` when wired, `{ tools: [], available: false, error? }` when unwired. Lets ACP clients probe capability before `prompt/execute`.
+- **Plugin manifest `modelCatalog` cold-read** (#81). `packages/providers/src/model-catalog.ts` exports `PluginManifestModelCatalog`, `hasPluginManifestModelCatalog`, `readPluginManifestModelCatalog`, `seedManifestCacheFromPlugin`. Defensive against unknown input shapes; works whether or not the plugins package eventually adds a typed `modelCatalog` field. (OpenClaw v2026.4.24.)
+- **Layering inversion fixed: `core` no longer depends on `plugins`** (#158). `Plugin` contract types + `PluginManager` moved into `packages/core/src/plugins.ts` and re-exported from `@crowclaw/core`. `@crowclaw/plugins` is now a re-export shim depending on core (correct direction). Identity check pins `CorePluginManager === ShimPluginManager` so all existing consumers keep working unchanged.
+- **DurableObjectIdempotencyStore unit suite** (#159). 12 dedicated tests covering concurrent same-key `markIfAbsent`, TTL expiry + eviction (fake timers), storage round-trip on hydrate (with expired-snapshot filtering, `unmark` persistence, storage.get failure fallback), and `maxEntries` cap eviction durability across hydrate cycles.
+
+### Repo hygiene
+- **Drop `'src'` from all 19 package `files` arrays** (#157). Halves install size for consumers; composite build verified clean. Per-package `types` still points to `src/index.ts` for workspace-internal type resolution — flipping to `dist/*.d.ts` for publishable artifacts is a v0.7 follow-up.
+- **Workspace name validation in postinstall** (#136). `link-workspaces.mjs` validates `@crowclaw/<segment>` against `/^[a-z0-9_-]+$/`; invalid names skipped with `console.warn`.
+- **Cross-cutting glossary** (#151). New `docs/glossary.md` maps `session`/`run`/`job`/`task`/`abort`/`stop` terminology across CLI/REST/EventBus/ACP/MCP, with explicit response-shape tables for the stop semantics (200 stopped / 202 pending / 404 not-active) and the v0.6.0 EventBus discriminated union. No code renames performed.
+
+### Cross-package contracts added / changed
+- `MemoryManager.shutdown(sessionId, messages): Promise<SessionEndResult[]>` + `MemoryProvider.onSessionEnd?(...)` — `@crowclaw/memory`
+- `WorkspaceReadDedup` exports — `@crowclaw/tools`
+- `WsAuthRateLimiter` + `GatewayIdempotencyClaim` + `claim()/poisonAfterProgress()/isPoisoned()` — `@crowclaw/gateway`
+- `McpClient.sessionIdleTtlMs` + lifecycle helpers — `@crowclaw/mcp`
+- `McpJsonRpcStdioTransport` `autoReconnect` / `reconnectMaxAttempts` / `reconnectInitialDelayMs` / `onReconnect` — `@crowclaw/mcp`
+- `PluginManifestModelCatalog` + `seedManifestCacheFromPlugin` — `@crowclaw/providers`
+- `AcpToolInfo` + `tools?:` callback — `@crowclaw/acp`
+- `pruneDeadBridgeProcesses(processes, maxAgeMs?)` — `@crowclaw/runtime-node/bridge-process`
+- `GatewayDebouncer.flush()` — `@crowclaw/runtime-node`
+- All `Plugin*` symbols now also exported from `@crowclaw/core` (canonical home) — `@crowclaw/plugins` becomes a shim
+
+### Verification
+- `npm run typecheck` — clean
+- `npm test` — 2,532 / 2,532 across 214 files (8.92s)
+- 111 new tests; full suite up from 2,421 → 2,532
+
+### Sources
+- Hermes (post-v0.11.0 catch-up): PRs #16569 (#84-class fork toolset wired), #16571 (#85), #16574 (#86), #16382 (#88).
+- OpenClaw v2026.4.25 + earlier: issue #69303/#58549 (#78 poison dedupe), v2026.4.24 (#80 sessionIdleTtl, #81 modelCatalog cold-read), CVE-2026-32025 (#69 WS auth limit).
+- Internal v0.6.0 audit follow-up: 14 audit items (#115-#128 #134 #136 #151 #157 #159).
+- Cross-cutting refactor: #156, #158.
+
 ## [0.6.0] — 2026-04-28 — 103-issue sweep: NemoClaw + post-v0.11.0 Hermes + OpenClaw v2026.4.25 parity, security hardening, leak fixes
 
 A single release closing **103 issues (#63–#165)** filed in an eight-agent triage round (security / reliability / perf / UX-flow / memory-retention / cross-cutting + external-pattern research against `NousResearch/hermes-agent` post-v0.11.0, `openclaw/openclaw` v2026.4.24+v2026.4.25, and `NVIDIA/NemoClaw` first 30 days). Implementation ran with 8-way parallel agent execution; 14 commits, ~57 files modified, 13 new files (5 helpers / 8 test files), +5,300 / -300 lines, **2,421 tests passing** (up from 2,187 — 234 new tests).

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
     <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License" /></a>
     <a href="#5-minute-quickstart"><img src="https://img.shields.io/badge/node-%3E%3D22-blue.svg" alt="Node 22+" /></a>
     <a href="#packages"><img src="https://img.shields.io/badge/packages-19-purple.svg" alt="19 packages" /></a>
-    <img src="https://img.shields.io/badge/tests-2421%20passed-brightgreen.svg" alt="Tests" />
+    <img src="https://img.shields.io/badge/tests-2532%20passed-brightgreen.svg" alt="Tests" />
     <a href="./CHANGELOG.md"><img src="https://img.shields.io/badge/changelog-v0.5.0-blue.svg" alt="Changelog" /></a>
   </p>
 </p>
 
 ---
 
-> **Beta. Single-maintainer, moving fast.** Pin exact versions. The agent loop and security surface are well-tested (2421 tests, five-agent cross-audit, 103-issue v0.6.0 sweep + 38-issue v0.5.0 sweep). Several subsystems are still partial — see [Feature status](#feature-status).
+> **Beta. Single-maintainer, moving fast.** Pin exact versions. The agent loop and security surface are well-tested (2532 tests, five-agent cross-audit, 26-issue v0.6.1 follow-up + 103-issue v0.6.0 sweep + 38-issue v0.5.0 sweep). Several subsystems are still partial — see [Feature status](#feature-status).
 
 CrowClaw gives you an agent loop, 50+ tools, skill learning, scheduled jobs, multi-channel webhooks, and a dashboard — without wiring the whole stack yourself.
 
@@ -204,7 +204,7 @@ Runtime adapters (`runtime-node`, `runtime-cloudflare`) wrap the runtime-agnosti
 
 | Area | Status |
 |---|---|
-| Agent loop (`@crowclaw/core`) | Beta — tested, five-agent cross-audit, 103-issue v0.6.0 sweep + 38-issue v0.5.0 sweep |
+| Agent loop (`@crowclaw/core`) | Beta — tested, five-agent cross-audit, 26-issue v0.6.1 follow-up + 103-issue v0.6.0 sweep + 38-issue v0.5.0 sweep |
 | Node.js runtime | Beta — primary runtime |
 | Cloudflare Workers runtime | **Early adapter** — functional, narrower override surface than Node |
 | Provider routing (OpenAI-compat / Anthropic) | Partial — credential pooling, prompt caching, fallback chain |
@@ -457,7 +457,7 @@ npm test             # vitest run
 npm run preflight    # both
 ```
 
-Coverage spans agent loop, providers, tools, memory, gateway (normalization + access policy), MCP, ACP, CLI, security (SSRF, auth rate limit, cookie hardening, CSP, hardline blocklist, MCP owner-only), browser, delegation, learning, plugins, scheduler, workspace, configuration API, and end-to-end wiring. **2421 tests** as of v0.6.0.
+Coverage spans agent loop, providers, tools, memory, gateway (normalization + access policy), MCP, ACP, CLI, security (SSRF, auth rate limit, cookie hardening, CSP, hardline blocklist, MCP owner-only), browser, delegation, learning, plugins, scheduler, workspace, configuration API, and end-to-end wiring. **2532 tests** as of v0.6.1.
 
 ## Packages
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,206 @@
+# CrowClaw Glossary (#151)
+
+A cross-cutting reference for terminology used in CrowClaw. The same concept
+sometimes carries different names across CLI flags, REST routes, EventBus
+event types, ACP RPCs, and MCP tool names — usually because each surface
+adopted the term that fit its own protocol idioms first. **No renames are
+planned for v0.6.x**; this doc just maps the surface area so contributors and
+integrators can navigate it.
+
+If a future major version (v1.x) does a breaking rename pass, the candidate
+canonical names are flagged below as `(canonical)`.
+
+## Core concepts
+
+### Session — `Session` `(canonical)`
+
+A long-lived conversation thread owned by a single agent. Persisted in the
+session store (`InMemorySessionStore`, `FileSessionStore`, `D1SessionStore`).
+Identified by `sessionId: string`.
+
+| Surface | Term | Notes |
+|---|---|---|
+| Core (`@crowclaw/core`) | `Session` | Type defined in `packages/shared`. |
+| REST | `/api/sessions/:id` | Path noun is `sessions`. |
+| WebSocket | `session:*` events | All lifecycle events are `session:`-prefixed. |
+| EventBus (`runtime-node`) | `session:created` / `session:updated` / `session:steered` / `session:aborted` / `session:forked` / `session:compacted` | See `event-bus.ts`. |
+| ACP | `sessions/list`, `sessions/create` | RPC methods. |
+| MCP | `crowclaw.sessions.list`, `crowclaw.sessions.get` | Tool names. |
+| CLI | `crowclaw session ...` (where exposed) | Aligned with REST. |
+
+**No alias**: `conversation` and `thread` are sometimes used in user-facing
+docs but never in code. Treat them as synonyms in prose only.
+
+### Run — single agent turn
+
+A single invocation of `Agent.run(input)` that produces a result. One session
+contains many runs. Not separately persisted — only the resulting messages
+are stored on the session.
+
+| Surface | Term | Notes |
+|---|---|---|
+| Core | `Agent.run(input: AgentRunInput): AgentRunResult` | Method on `Agent`. |
+| Core (streaming) | `Agent.runStream(input)` | Yields events as they arrive. |
+| Scheduler | "run" in `runJob`, `RunContext`, `run-history` | A scheduler tick *executes* a job, producing a run. |
+| EventBus | no dedicated `run:*` type | Run boundaries surface as `session:updated`. |
+| ACP | `sessions/run` | RPC method on a session. |
+| MCP | `crowclaw.chat` | The MCP tool wrapping the canonical chat → run flow. |
+
+**Disambiguation**: scheduler "runs" are a strict subset — they're runs
+triggered by a cron tick rather than a user message.
+
+### Job — `CronJobDefinition` (scheduler-only)
+
+A scheduled, recurring agent task definition stored by `SchedulerStore`.
+Carries a cron expression, target agent, prompt, and per-job constraints
+(`enabledToolsets`, `timeoutMs`, `inactivityTimeoutMs`, `wallClockTimeoutMs`).
+
+| Surface | Term | Notes |
+|---|---|---|
+| Scheduler | `CronJobDefinition`, `SchedulerStore.{listJobs, saveJob}` | The job is the *definition*, not an execution. |
+| EventBus | `scheduler:*` (where wired) | Job lifecycle events. |
+| REST | `/api/scheduler/jobs/...`, `/api/scheduler/stop` | |
+| MCP | `crowclaw.scheduler.create`, `crowclaw.scheduler.list` | Privileged tool. |
+
+A "job" is **not** the same as a "run". One job produces many runs over its
+lifetime.
+
+### Task — informal, not a typed concept
+
+Used in three distinct, non-canonical ways. **Not a typed primitive.**
+
+1. **Fork task** — `forkSession(parent, task, childAgentId)` accepts a task
+   string that becomes the seed user message of the child session. (Local
+   to `@crowclaw/core` `forkSession()`.)
+2. **Tool/skill task description** — free-form description in plugin manifests
+   and skills. Just metadata.
+3. **User-facing copy** — "task" appears in dashboard UI as a synonym for
+   "what the user asked the agent to do". Pure UI copy.
+
+If you find yourself needing a "task" type, you almost certainly want
+`Session`, `AgentRunInput`, or `CronJobDefinition` instead.
+
+## Lifecycle actions: abort vs stop
+
+These two action endpoints overlap but are **not** interchangeable. The
+distinction is **synchronous wait** vs **fire-and-forget signal**.
+
+| Action | Path | Behavior | Response |
+|---|---|---|---|
+| `abort` | `POST /api/sessions/:id/abort` | Signals the session controller to abort. Returns immediately. | `200 { ok: <bool>, aborted: <bool>, reason?: string }` |
+| `stop` | `POST /api/sessions/:id/stop` | Signals abort, then **waits up to 5s** for the session to leave the active set. | See below. |
+
+### `stop` response shapes (#59)
+
+| HTTP | Body | Meaning |
+|---|---|---|
+| `200` | `{ ok: true, status: "stopped", sessionId }` | Aborted and drained within 5s. Caller can rely on session being inactive. |
+| `202` | `{ ok: true, status: "pending", sessionId }` | Abort signalled; session still winding down. Caller should poll `GET /api/sessions/active`. |
+| `404` | `{ ok: false, status: "not-active", reason }` | Session was not in the active set when stop was received. |
+
+### `abort` response shape
+
+```json
+{
+  "ok": true,
+  "aborted": true,
+  "reason": "<optional string when aborted=false>"
+}
+```
+
+`aborted: false` means the session was already not running (treated as a
+no-op; HTTP status remains 200).
+
+### When to use which
+
+- **Use `abort`** for fire-and-forget cancel (CLI Ctrl+C, dashboard
+  abort button) where you don't need to know whether drain finished.
+- **Use `stop`** when the next request **depends** on the session having
+  fully released its mutex / cleared in-flight tool calls (CI tear-down,
+  destructive workspace operations on the same session id).
+
+The WebSocket `session:abort` message has the same semantics as
+`POST /abort` — fire-and-forget signal.
+
+## Lifecycle events (EventBus)
+
+Discriminated union introduced in #147 (v0.6.0). Previously all
+non-message changes were squashed into `session:updated` with an untyped
+`action` field — that pattern is now legacy.
+
+| Event type | Payload (key fields) | Emitted from |
+|---|---|---|
+| `session:created` | `sessionId, agentId` | session create handler |
+| `session:updated` | `sessionId, messageCount` | message append, generic update |
+| `session:steered` | `sessionId, directiveLength` | `/steer` |
+| `session:aborted` | `sessionId, reason?` | `/abort` and `/stop` |
+| `session:forked` | `sessionId, parentSessionId, parentAgentId, childAgentId` | `/fork` |
+| `session:compacted` | `sessionId, removedMessages, summaryLength` | `/compact` |
+
+Dashboard handlers in `packages/web/ui/src/app.ts` dispatch per type and emit
+DOM events that `chat-view` consumes for timeline markers.
+
+## Provider / gateway terminology
+
+Spelled out here to avoid confusion across Hermes / OpenClaw / NemoClaw
+parity work.
+
+| Term | Meaning |
+|---|---|
+| **Provider** | A backend LLM service: Anthropic, OpenAI, Gemini, NVIDIA, xAI, OpenRouter. `ProviderAdapter` per provider. |
+| **Model** | A specific model id under a provider, e.g. `claude-opus-4-5`. `ModelMetadata` includes `vision`, `requestTimeoutMs`. |
+| **Gateway** | The runner that turns a request into a provider call, applies retries, fallback chain, credential pool, rate limit. |
+| **Credential pool** | `ProviderKeyPool` — multiple keys per provider with `least_used` / `round_robin` cursor and 401-rotation. |
+| **Fallback chain** | Ordered `GatewayConfig.fallbackProviders`. On hop, emits `gateway:fallback_used`. |
+
+## Tool / skill / plugin / preset
+
+Frequently confused. They are layered, not synonyms.
+
+| Term | Definition | Where it lives |
+|---|---|---|
+| **Tool** | A single callable function exposed to the agent (e.g. `web.search`, `terminal.exec`). Naming convention `namespace.action`. | `@crowclaw/tools`, `@crowclaw/mcp` |
+| **Toolset** | A named bundle of tools. Plumbed via `enabledToolsets: string[]`. | All packages that gate tools (forks, cron jobs, MCP scope). |
+| **Skill** | A markdown-described capability (a SKILL.md file). May reference one or more tools, plus prompt fragments. | `@crowclaw/workspace` (SKILL.md path safety), agent prompt assembly. |
+| **Plugin** | Code-level extension implementing `Plugin` interface (`preToolCall`, `transformToolResult`, etc.). | `@crowclaw/plugins` |
+| **Preset** | An MCP+Skill+Tool **bundle** named for quick onboarding. Not a "persona". | Config layer. |
+
+**Reminder**: presets are bundles, not personas. See `CLAUDE.md` (project).
+
+## Tool naming convention
+
+All tools use `namespace.action`:
+
+| Pattern | Examples |
+|---|---|
+| `web.*` | `web.search`, `web.fetch` |
+| `terminal.*` | `terminal.exec`, `terminal.spawn` |
+| `sandbox.*` | `sandbox.run` |
+| `scheduler.*` | `scheduler.create`, `scheduler.list` |
+| `crowclaw.*` (MCP only) | `crowclaw.chat`, `crowclaw.sessions.list`, `crowclaw.sessions.get` |
+
+The `crowclaw.` prefix is reserved for the MCP server's privileged surface
+(maps to runtime-internal capabilities). Tool authors should not introduce
+new top-level namespaces without a contract review.
+
+## Quick term overlap matrix
+
+| Concept | CLI | REST | EventBus | ACP | MCP |
+|---|---|---|---|---|---|
+| Session | `crowclaw session …` | `/api/sessions/:id` | `session:*` | `sessions/list`, `sessions/create` | `crowclaw.sessions.list` |
+| One run | (implicit per message) | `POST /api/sessions/:id/messages` | `session:updated` | `sessions/run` | `crowclaw.chat` |
+| Cancel (signal) | Ctrl+C | `POST /abort` | `session:aborted` | — | — |
+| Cancel (drain) | — | `POST /stop` | `session:aborted` | — | — |
+| Steer | — | `POST /steer` | `session:steered` | — | — |
+| Fork | — | `POST /fork` | `session:forked` | — | — |
+| Compact | — | `POST /compact` | `session:compacted` | — | — |
+| Cron job | — | `/api/scheduler/jobs` | `scheduler:*` | — | `crowclaw.scheduler.*` |
+
+## See also
+
+- `packages/runtime-node/src/event-bus.ts` — EventBus discriminated union.
+- `packages/runtime-node/src/route-paths.ts` — Canonical REST path strings.
+- `packages/scheduler/src/index.ts` — `CronJobDefinition`, `RunContext`.
+- `packages/acp/src/index.ts` — ACP RPC method names.
+- `packages/mcp-server/src/index.ts` — MCP tool names.
+- `CHANGELOG.md` v0.6.0 — `RuntimeEventType` extension and `routePaths.sessions.*` listing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowclaw",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "A self-improving TypeScript agent framework that learns from every conversation.",
   "bin": {

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/acp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.0"
+    "@crowclaw/core": "0.6.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/acp/src/index.ts
+++ b/packages/acp/src/index.ts
@@ -49,6 +49,18 @@ export interface AcpAgentManifest {
   features?: string[];
 }
 
+/**
+ * Issue #148: Tool descriptor surfaced via `tools/list`. Mirrors the MCP
+ * shape so callers can pipe straight from a registry without a translation
+ * layer. `inputSchema` is optional — registries that don't ship JSON Schema
+ * yet just omit it.
+ */
+export interface AcpToolInfo {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
 // ---------------------------------------------------------------------------
 // Agent loop interface expected by the ACP server
 // ---------------------------------------------------------------------------
@@ -88,6 +100,16 @@ export class AcpServer {
       agentId?: string;
       displayName?: string;
       version?: string;
+      /**
+       * Issue #148: Optional registry callback that returns the live tool
+       * surface. When provided, `tools/list` returns `{ tools, available: true }`.
+       * When omitted, `tools/list` returns `{ tools: [], available: false }`
+       * to signal the bridge is wired but no registry is connected — clients
+       * can detect the difference and fall back to MCP. Errors thrown by the
+       * callback are caught and surface as `available: false` with an
+       * `error` field rather than failing the request.
+       */
+      tools?: () => AcpToolInfo[] | Promise<AcpToolInfo[]>;
     },
   ) {}
 
@@ -179,8 +201,20 @@ export class AcpServer {
           });
         }
 
-        case 'tools/list':
-          return this.respondOk(id, { tools: [] });
+        case 'tools/list': {
+          // Issue #148: surface the registry callback when wired; otherwise
+          // signal availability=false so clients can route through MCP.
+          if (!this.options?.tools) {
+            return this.respondOk(id, { tools: [], available: false });
+          }
+          try {
+            const tools = await this.options.tools();
+            return this.respondOk(id, { tools, available: true });
+          } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            return this.respondOk(id, { tools: [], available: false, error: message });
+          }
+        }
 
         case 'shutdown':
           this.shutdownRequested = true;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,8 +14,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,13 +15,9 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "@crowclaw/plugins": "0.6.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,18 @@
-import { PluginManager } from '@crowclaw/plugins';
+import { PluginManager } from './plugins.js';
+export {
+  PluginManager,
+  MemoryCapturePlugin,
+} from './plugins.js';
+export type {
+  Plugin,
+  PluginContext,
+  PluginHookName,
+  PluginHookPayloads,
+  PluginInvocationName,
+  PluginInvocationPayloads,
+  PreToolCallVeto,
+  ToolResultTransform,
+} from './plugins.js';
 import { buildSystemPrompt, buildMemoryPrefix, type PromptBuilderInput } from './prompt-builder.js';
 import { matchSkillManifests, filterAndBudgetSkills, checkSkillGates, type ParsedSkillFile, type SkillManifest } from './skill-manifest.js';
 import type { MatchedSkill } from './prompt-builder.js';

--- a/packages/core/src/plugins.ts
+++ b/packages/core/src/plugins.ts
@@ -1,0 +1,193 @@
+/**
+ * Plugin contract + manager.
+ *
+ * Owned by `@crowclaw/core` (issue #158). The legacy `@crowclaw/plugins`
+ * package re-exports everything below as a backward-compat shim. This keeps
+ * the dependency direction sane — runtime/test code may depend on either
+ * `@crowclaw/core` (preferred) or `@crowclaw/plugins` (shim), and both reach
+ * the same definitions defined here.
+ */
+
+export interface PluginContext {
+  runtime: string;
+  sessionId: string;
+  agentId: string;
+}
+
+/**
+ * #95: Plugin can veto a tool call before execution.
+ * Return `{ veto: true, reason }` to block; return `{ veto: false }` (or
+ * undefined / void) to allow. The agent loop OR-aggregates across plugins:
+ * any single veto blocks the call.
+ */
+export interface PreToolCallVeto {
+  veto: boolean;
+  reason?: string;
+}
+
+/**
+ * #95: Plugin can transform a tool result after execution but before the
+ * agent loop appends it to conversation history. Return a partial override
+ * (only the fields you want to change) or undefined to leave it untouched.
+ *
+ * Note: this runs *after* core's redaction + injection-scan layer, so plugins
+ * see the already-redacted output. They cannot un-redact.
+ */
+export interface ToolResultTransform {
+  output?: string;
+  ok?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PluginHookPayloads {
+  'agent:beforeRun': { input: { agentId: string; sessionId: string; [key: string]: unknown } };
+  'agent:afterRun': { input: { agentId: string; sessionId: string; [key: string]: unknown }; result: { finalResponse: string; toolResults: Array<{ toolName: string; ok: boolean }> } };
+  'provider:beforeGenerate': { attempt: number; providerIndex: number; messageCount: number };
+  'provider:afterGenerate': { attempt: number; providerIndex: number; messageCount: number; toolCallCount: number; assistantMessage?: string };
+  'provider:error': { attempt: number; providerIndex: number; messageCount: number; error: string };
+  'tool:beforeExecute': { toolName: string; input: Record<string, unknown>; sessionId: string; agentId: string };
+  'tool:result': { result: { toolName: string; ok: boolean; output: string }; sessionId: string; agentId: string };
+  'tool:error': { result: { toolName: string; ok: boolean; output: string }; sessionId: string; agentId: string };
+}
+
+/**
+ * #95: Hooks that *return* a value (veto / transform) are kept separate from
+ * the fire-and-forget `on` hooks so their signatures can encode return types
+ * cleanly. Plugins implement only the methods they care about.
+ */
+export interface PluginInvocationPayloads {
+  /** Pre-execution gate. Plugins return `{veto:true,reason}` to block. */
+  'tool:preExecute': {
+    payload: { toolName: string; input: Record<string, unknown>; sessionId: string; agentId: string };
+    result: PreToolCallVeto | void;
+  };
+  /** Post-execution transform. Plugins return a partial override of the tool result. */
+  'tool:transformResult': {
+    payload: {
+      toolName: string;
+      input: Record<string, unknown>;
+      result: { toolName: string; ok: boolean; output: string; metadata?: Record<string, unknown> };
+      sessionId: string;
+      agentId: string;
+    };
+    result: ToolResultTransform | void;
+  };
+}
+
+export type PluginHookName = keyof PluginHookPayloads;
+export type PluginInvocationName = keyof PluginInvocationPayloads;
+
+export interface Plugin {
+  name: string;
+  /** Fire-and-forget observer hooks. */
+  on?<K extends PluginHookName>(hook: K, payload: PluginHookPayloads[K], context: PluginContext): Promise<void> | void;
+  /**
+   * #95: Pre-execution veto. Return `{veto:true,reason}` to block this tool
+   * call. Multiple plugins are OR-aggregated: any veto blocks. Throwing here
+   * is treated as a non-vetoing error and logged; it never blocks.
+   */
+  preToolCall?(
+    payload: PluginInvocationPayloads['tool:preExecute']['payload'],
+    context: PluginContext,
+  ): Promise<PreToolCallVeto | void> | PreToolCallVeto | void;
+  /**
+   * #95: Post-execution transform. Return a partial override of the result
+   * (any field you don't return is preserved). Plugins are applied in
+   * registration order; later plugins see the output of earlier ones.
+   * Throwing here passes the previous result through unchanged.
+   */
+  transformToolResult?(
+    payload: PluginInvocationPayloads['tool:transformResult']['payload'],
+    context: PluginContext,
+  ): Promise<ToolResultTransform | void> | ToolResultTransform | void;
+}
+
+export class PluginManager {
+  private readonly plugins = new Map<string, Plugin>();
+
+  register(plugin: Plugin): this {
+    this.plugins.set(plugin.name, plugin);
+    return this;
+  }
+
+  list(): Plugin[] {
+    return [...this.plugins.values()];
+  }
+
+  async emit<K extends PluginHookName>(hook: K, payload: PluginHookPayloads[K], context: PluginContext): Promise<void> {
+    for (const plugin of this.plugins.values()) {
+      await plugin.on?.(hook, payload, context);
+    }
+  }
+
+  /**
+   * #95: Run pre-tool-call gates across all plugins. OR-aggregates: the first
+   * `veto:true` short-circuits and is returned. Plugin throws are caught and
+   * treated as non-vetoing (we don't want a buggy plugin to lock out tools).
+   */
+  async preToolCall(
+    payload: PluginInvocationPayloads['tool:preExecute']['payload'],
+    context: PluginContext,
+  ): Promise<PreToolCallVeto> {
+    for (const plugin of this.plugins.values()) {
+      if (!plugin.preToolCall) continue;
+      try {
+        const verdict = await plugin.preToolCall(payload, context);
+        if (verdict && verdict.veto) {
+          return {
+            veto: true,
+            reason: verdict.reason ? `${plugin.name}: ${verdict.reason}` : `${plugin.name}: vetoed`,
+          };
+        }
+      } catch (error) {
+        // Buggy plugin must not block tools — log and continue.
+        // (We don't have a logger here; best the manager can do is swallow.)
+        void error;
+      }
+    }
+    return { veto: false };
+  }
+
+  /**
+   * #95: Run post-tool-call transforms across all plugins. Each plugin sees
+   * the output of the previous transform; returning `void`/undefined leaves
+   * the running result unchanged. Plugin throws revert to the prior result.
+   */
+  async transformToolResult(
+    payload: PluginInvocationPayloads['tool:transformResult']['payload'],
+    context: PluginContext,
+  ): Promise<{ toolName: string; ok: boolean; output: string; metadata?: Record<string, unknown> }> {
+    let current = payload.result;
+    for (const plugin of this.plugins.values()) {
+      if (!plugin.transformToolResult) continue;
+      try {
+        const transform = await plugin.transformToolResult(
+          { ...payload, result: current },
+          context,
+        );
+        if (!transform) continue;
+        current = {
+          toolName: current.toolName,
+          ok: transform.ok ?? current.ok,
+          output: transform.output ?? current.output,
+          metadata: transform.metadata
+            ? { ...(current.metadata ?? {}), ...transform.metadata }
+            : current.metadata,
+        };
+      } catch (error) {
+        // Plugin error: keep prior result, continue with the next plugin.
+        void error;
+      }
+    }
+    return current;
+  }
+}
+
+export class MemoryCapturePlugin implements Plugin {
+  readonly name = 'memory-capture';
+  public seen: Array<{ hook: PluginHookName; sessionId: string }> = [];
+
+  async on<K extends PluginHookName>(hook: K, _payload: PluginHookPayloads[K], context: PluginContext): Promise<void> {
+    this.seen.push({ hook, sessionId: context.sessionId });
+  }
+}

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/gateway",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -19,8 +19,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -15,6 +15,212 @@ function validateFetchUrl(url: string): { safe: boolean; reason?: string } {
   } catch { return { safe: false, reason: 'Invalid URL' }; }
 }
 
+// ---------------------------------------------------------------------------
+// Issue #134: Bot-token scrubbing for error messages and URLs.
+//
+// Telegram puts the bot token directly in the URL path (`/bot<TOKEN>/...`),
+// so any stack trace, fetch error, or proxy-debug log can leak it. Scrub
+// before storing in `status.error` (returned by /api/gateway/status) or
+// emitting to logs. The pattern matches Telegram bot tokens specifically:
+// digits, colon, then base64url-ish body. Other platforms with tokens-in-URL
+// (none today, but future-proof) can be added here.
+// ---------------------------------------------------------------------------
+
+const BOT_TOKEN_PATTERN = /bot\d+:[A-Za-z0-9_-]+/g;
+
+/**
+ * Replace any Telegram-style bot token (`bot<digits>:<base64url>`) with
+ * `bot[REDACTED]` so secrets never escape into status payloads or logs.
+ * Returns the input unchanged when it contains no token.
+ */
+export function scrubBotToken(text: string): string {
+  if (!text) return text;
+  return text.replace(BOT_TOKEN_PATTERN, 'bot[REDACTED]');
+}
+
+// ---------------------------------------------------------------------------
+// Issue #69: WebSocket auth rate limiter with exponential backoff bans.
+//
+// The runtime-node `/ws` upgrade path used to be unprotected: an attacker
+// could brute-force the dashboard token at HTTP-handshake speed. This
+// limiter is shared between gateway and runtime-node so the same per-IP
+// budget governs every WS auth attempt.
+//
+// Counts only *failed* auth attempts (the caller decides what counts as
+// failure). After `maxAttempts` failures inside `windowMs`, the IP is
+// banned for `baseBanMs * 2^N` (capped at `maxBanMs`), where N is the
+// number of consecutive ban escalations. A successful auth resets both
+// the failure window AND the ban escalation counter for that IP.
+// ---------------------------------------------------------------------------
+
+export interface WsAuthRateLimiterOptions {
+  /** Failed-attempt cap inside `windowMs` before the IP is banned. Default 5. */
+  maxAttempts?: number;
+  /** Sliding window for counting failures. Default 60_000 ms (1 minute). */
+  windowMs?: number;
+  /** Initial ban duration. Default 5 * 60_000 ms (5 minutes). */
+  baseBanMs?: number;
+  /** Hard cap on exponential ban duration. Default 60 * 60_000 ms (1 hour). */
+  maxBanMs?: number;
+  /** Soft cap on tracked IPs to bound memory. Default 10_000. */
+  maxKeys?: number;
+}
+
+export interface WsAuthRateLimiterDecision {
+  /** True if the upgrade should proceed to auth, false if it must be rejected. */
+  allowed: boolean;
+  /** Seconds until the ban lifts. Always present when `allowed` is false. */
+  retryAfterSec?: number;
+  /** Reason code for logging. */
+  reason?: 'rate-limited' | 'banned';
+}
+
+/**
+ * Per-IP WebSocket auth rate limiter with exponential backoff bans (issue #69).
+ *
+ * Usage:
+ *   const limiter = new WsAuthRateLimiter();
+ *   const decision = limiter.beforeAuth(clientIp);
+ *   if (!decision.allowed) return new Response('Too many attempts', { status: 429, headers: { 'Retry-After': String(decision.retryAfterSec) } });
+ *   const ok = await checkAuth(...);
+ *   if (ok) limiter.recordSuccess(clientIp); else limiter.recordFailure(clientIp);
+ */
+export class WsAuthRateLimiter {
+  private readonly maxAttempts: number;
+  private readonly windowMs: number;
+  private readonly baseBanMs: number;
+  private readonly maxBanMs: number;
+  private readonly maxKeys: number;
+
+  // Per-IP failure timestamps inside the sliding window.
+  private readonly failures = new Map<string, number[]>();
+  // Per-IP ban entry: { until: epoch ms when the ban lifts, level: # of escalations so far }.
+  private readonly bans = new Map<string, { until: number; level: number }>();
+
+  constructor(opts?: WsAuthRateLimiterOptions) {
+    this.maxAttempts = Math.max(1, opts?.maxAttempts ?? 5);
+    this.windowMs = Math.max(1_000, opts?.windowMs ?? 60_000);
+    this.baseBanMs = Math.max(1_000, opts?.baseBanMs ?? 5 * 60_000);
+    this.maxBanMs = Math.max(this.baseBanMs, opts?.maxBanMs ?? 60 * 60_000);
+    this.maxKeys = Math.max(100, opts?.maxKeys ?? 10_000);
+  }
+
+  /**
+   * Check whether `ip` may proceed to auth. Call this before reading or
+   * comparing the auth credential. Returns a decision; on `allowed: false`
+   * the caller must short-circuit with 429 and respect `retryAfterSec`.
+   */
+  beforeAuth(ip: string): WsAuthRateLimiterDecision {
+    const now = Date.now();
+    const ban = this.bans.get(ip);
+    if (ban && ban.until > now) {
+      return { allowed: false, retryAfterSec: Math.ceil((ban.until - now) / 1000), reason: 'banned' };
+    }
+    if (ban && ban.until <= now) {
+      // Ban window passed but escalation level is preserved so the next
+      // burst lands a longer ban. We only forget the ban entirely after a
+      // verified success (recordSuccess) — see resetEscalation below.
+      this.bans.delete(ip);
+      // Re-insert with `until = 0` so the level survives the prune scan.
+      this.bans.set(ip, { until: 0, level: ban.level });
+    }
+    // Even outside an active ban, if we already have N failures in the
+    // window we deny pre-emptively to avoid a thundering herd while the
+    // ban transition is being computed by recordFailure.
+    const recent = this.failures.get(ip);
+    if (recent) {
+      const cutoff = now - this.windowMs;
+      while (recent.length > 0 && recent[0]! <= cutoff) recent.shift();
+      if (recent.length >= this.maxAttempts) {
+        // Emit a fresh ban so the caller can include Retry-After.
+        const ban2 = this.bans.get(ip);
+        const level = (ban2?.level ?? 0) + 1;
+        const banMs = Math.min(this.maxBanMs, this.baseBanMs * Math.pow(2, Math.max(0, level - 1)));
+        const until = now + banMs;
+        this.bans.set(ip, { until, level });
+        // Clear failure window — replay protection now lives in the ban.
+        this.failures.delete(ip);
+        this.evictIfNeeded();
+        return { allowed: false, retryAfterSec: Math.ceil(banMs / 1000), reason: 'rate-limited' };
+      }
+    }
+    return { allowed: true };
+  }
+
+  /** Record a failed auth attempt. Triggers a ban once threshold is reached. */
+  recordFailure(ip: string): void {
+    const now = Date.now();
+    let arr = this.failures.get(ip);
+    if (!arr) {
+      arr = [];
+      this.failures.set(ip, arr);
+    }
+    const cutoff = now - this.windowMs;
+    while (arr.length > 0 && arr[0]! <= cutoff) arr.shift();
+    arr.push(now);
+    if (arr.length >= this.maxAttempts) {
+      const existing = this.bans.get(ip);
+      const level = (existing?.level ?? 0) + 1;
+      const banMs = Math.min(this.maxBanMs, this.baseBanMs * Math.pow(2, Math.max(0, level - 1)));
+      this.bans.set(ip, { until: now + banMs, level });
+      this.failures.delete(ip);
+    }
+    this.evictIfNeeded();
+  }
+
+  /** Record a successful auth. Clears failures and ban-escalation level. */
+  recordSuccess(ip: string): void {
+    this.failures.delete(ip);
+    this.bans.delete(ip);
+  }
+
+  /** Test hook — clear all state. */
+  reset(): void {
+    this.failures.clear();
+    this.bans.clear();
+  }
+
+  /** Test hook — peek at current ban for `ip`, or `null` if none. */
+  getBan(ip: string): { until: number; level: number } | null {
+    return this.bans.get(ip) ?? null;
+  }
+
+  /** Test hook — current failure count inside the active window. */
+  getFailureCount(ip: string): number {
+    const arr = this.failures.get(ip);
+    if (!arr) return 0;
+    const cutoff = Date.now() - this.windowMs;
+    let live = 0;
+    for (let i = arr.length - 1; i >= 0; i -= 1) {
+      if (arr[i]! > cutoff) live += 1;
+      else break;
+    }
+    return live;
+  }
+
+  /** Bound memory: drop oldest tracked IPs once we exceed maxKeys. */
+  private evictIfNeeded(): void {
+    if (this.failures.size > this.maxKeys) {
+      const overflow = this.failures.size - this.maxKeys;
+      let removed = 0;
+      for (const k of this.failures.keys()) {
+        if (removed >= overflow) break;
+        this.failures.delete(k);
+        removed += 1;
+      }
+    }
+    if (this.bans.size > this.maxKeys) {
+      const overflow = this.bans.size - this.maxKeys;
+      let removed = 0;
+      for (const k of this.bans.keys()) {
+        if (removed >= overflow) break;
+        this.bans.delete(k);
+        removed += 1;
+      }
+    }
+  }
+}
+
 export interface NormalizedInboundMessage {
   platform: GatewayPlatform;
   channelId: string;
@@ -524,19 +730,45 @@ export interface GatewayDeliveryPlan {
  * newly recorded and `false` when an unexpired entry already existed. The
  * legacy `mark` method remains for backcompat and internally delegates to
  * `markIfAbsent`.
+ *
+ * Issue #78: Once visible progress occurs (a tool side-effect ran or a token
+ * streamed to the user), call `poisonAfterProgress(key)`. After that, any
+ * subsequent claim attempt for the same key reports `'poisoned'` rather than
+ * silently re-running the side-effect. The runtime surfaces this as 409 to
+ * the platform so retried inbound deliveries fail loud instead of replaying.
  */
+export type GatewayIdempotencyClaim = 'fresh' | 'duplicate' | 'poisoned';
+
 export interface GatewayIdempotencyStore {
   /**
    * Atomically record `key` if it is not already present.
    * Returns `true` if the key was newly recorded, `false` if a still-valid
    * entry already existed. The optional `ttlMs` overrides the store default.
+   *
+   * Note: This boolean form is preserved for backcompat. New code should
+   * prefer `claim()` so the poisoned state is surfaced.
    */
   markIfAbsent(key: string, ttlMs?: number): Promise<boolean>;
+  /**
+   * Issue #78: Tri-state claim that distinguishes fresh / duplicate /
+   * poisoned. Implementations without poisoning support should return
+   * `'fresh' | 'duplicate'` only, matching `markIfAbsent` semantics.
+   */
+  claim?(key: string, ttlMs?: number): Promise<GatewayIdempotencyClaim>;
+  /**
+   * Issue #78: Mark `key` as poisoned because visible progress happened.
+   * Subsequent `claim` calls return `'poisoned'`; subsequent `markIfAbsent`
+   * calls return `false` (a poisoned entry counts as occupied).
+   * No-op if the key is unknown or expired.
+   */
+  poisonAfterProgress?(key: string, ttlMs?: number): Promise<void>;
   /** Remove `key`. Used when downstream processing fails and the caller
    * wants the next retry delivery to be considered fresh. */
   unmark(key: string): Promise<void>;
   /** Whether `key` has an unexpired entry. */
   has(key: string): Promise<boolean>;
+  /** Whether `key` is currently poisoned (issue #78). */
+  isPoisoned?(key: string): Promise<boolean>;
   /** Backcompat shim — equivalent to `markIfAbsent` but discards the result. */
   mark(key: string, ttlMs?: number): Promise<void>;
 }
@@ -558,6 +790,11 @@ export class InMemoryGatewayIdempotencyStore implements GatewayIdempotencyStore 
   // inserted earlier expire earlier, so the iteration order also doubles as
   // an "oldest expiresAt first" ordering for cap-based eviction.
   private readonly entries = new Map<string, number>(); // key -> expiresAt epoch ms
+  // Issue #78: poisoned keys map to the same expiresAt domain. A poisoned
+  // entry is still "present" for `markIfAbsent`/`has` (so dedupe still
+  // rejects), but `claim()` reports `'poisoned'` so the runtime can return
+  // 409 instead of silently re-running side-effects.
+  private readonly poisoned = new Map<string, number>(); // key -> expiresAt epoch ms
   private readonly defaultTtlMs: number;
   private readonly maxEntries: number;
 
@@ -582,6 +819,11 @@ export class InMemoryGatewayIdempotencyStore implements GatewayIdempotencyStore 
         //  because prune runs once per mutation, not per check.)
       }
     }
+    // Drop expired poison markers in the same sweep so they cannot grow
+    // unbounded. Poison TTL mirrors the entry TTL.
+    for (const [key, expiresAt] of this.poisoned) {
+      if (expiresAt <= now) this.poisoned.delete(key);
+    }
     // 2. Enforce cap by evicting oldest entries first.
     if (this.entries.size > this.maxEntries) {
       const overflow = this.entries.size - this.maxEntries;
@@ -589,6 +831,8 @@ export class InMemoryGatewayIdempotencyStore implements GatewayIdempotencyStore 
       for (const key of this.entries.keys()) {
         if (removed >= overflow) break;
         this.entries.delete(key);
+        // Drop matching poison marker so we don't keep stale poison forever.
+        this.poisoned.delete(key);
         removed++;
       }
     }
@@ -601,6 +845,12 @@ export class InMemoryGatewayIdempotencyStore implements GatewayIdempotencyStore 
     if (existing !== undefined && existing > now) {
       return false;
     }
+    // Issue #78: poisoned-without-entry can happen if the entry was unmarked
+    // after poisoning (operator-driven). Treat as occupied — never re-run.
+    const poisonedAt = this.poisoned.get(key);
+    if (poisonedAt !== undefined && poisonedAt > now) {
+      return false;
+    }
     // If the existing entry was expired, delete first so re-set lands at the
     // tail of insertion order (matching new-entry semantics for eviction).
     if (existing !== undefined) {
@@ -610,8 +860,61 @@ export class InMemoryGatewayIdempotencyStore implements GatewayIdempotencyStore 
     return true;
   }
 
+  /**
+   * Issue #78: tri-state claim. `'fresh'` = newly recorded, claim succeeded.
+   * `'duplicate'` = unexpired entry exists but no side-effects yet (caller
+   * may choose to wait/retry the *same* outbound). `'poisoned'` = visible
+   * progress already happened; the caller MUST NOT replay and should surface
+   * a 409 to the platform.
+   */
+  async claim(key: string, ttlMs: number = this.defaultTtlMs): Promise<GatewayIdempotencyClaim> {
+    const now = Date.now();
+    this.prune(now);
+    const poisonedAt = this.poisoned.get(key);
+    if (poisonedAt !== undefined && poisonedAt > now) {
+      return 'poisoned';
+    }
+    const existing = this.entries.get(key);
+    if (existing !== undefined && existing > now) {
+      return 'duplicate';
+    }
+    if (existing !== undefined) {
+      this.entries.delete(key);
+    }
+    this.entries.set(key, now + ttlMs);
+    return 'fresh';
+  }
+
+  /**
+   * Issue #78: mark `key` as poisoned because the inbound delivery has
+   * caused user-visible progress (tool side-effect, streamed token, etc).
+   * Subsequent claims return `'poisoned'`. Idempotent.
+   */
+  async poisonAfterProgress(key: string, ttlMs: number = this.defaultTtlMs): Promise<void> {
+    const now = Date.now();
+    this.poisoned.set(key, now + ttlMs);
+    // Refresh the entry's expiresAt too so `markIfAbsent` keeps treating the
+    // key as occupied for the same window. This avoids a race where the
+    // entry expires before the poison marker.
+    if (this.entries.has(key)) {
+      this.entries.set(key, now + ttlMs);
+    }
+  }
+
+  async isPoisoned(key: string): Promise<boolean> {
+    const expiresAt = this.poisoned.get(key);
+    if (expiresAt === undefined) return false;
+    if (expiresAt <= Date.now()) {
+      this.poisoned.delete(key);
+      return false;
+    }
+    return true;
+  }
+
   async unmark(key: string): Promise<void> {
     this.entries.delete(key);
+    // Note: do NOT drop the poison marker. If the operator unmarks a key
+    // that has produced visible progress, replays should still fail loud.
   }
 
   async has(key: string): Promise<boolean> {

--- a/packages/gateway/src/runner.ts
+++ b/packages/gateway/src/runner.ts
@@ -13,10 +13,56 @@ import {
   buildGatewayRetryPolicy,
   createTypingIndicator,
   normalizeTelegramWebhook,
+  scrubBotToken,
   sendTelegramMessage,
 } from './index.js';
 import { executeWithRetry } from './retry.js';
 import { PlatformRateLimiter } from './platform-rate-limiter.js';
+
+// ---------------------------------------------------------------------------
+// Issue #109: Minimal p-limit-style concurrency gate.
+//
+// The Telegram polling loop used to await `onMessage` per update sequentially.
+// A burst of 10 messages serialized 10 LLM calls for users in different chats.
+// This gate runs up to `max` updates concurrently. Kept inline so the gateway
+// stays zero-dep (matching the comment at the top of `index.ts`).
+// ---------------------------------------------------------------------------
+function createConcurrencyLimiter(
+  max: number,
+): <T>(fn: () => Promise<T>) => Promise<T> {
+  const limit = Math.max(1, Math.floor(max));
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const next = (): void => {
+    if (active >= limit) return;
+    const run = queue.shift();
+    if (run) run();
+  };
+
+  return <T>(fn: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const start = (): void => {
+        active += 1;
+        Promise.resolve()
+          .then(fn)
+          .then(
+            (value) => {
+              active -= 1;
+              resolve(value);
+              next();
+            },
+            (err: unknown) => {
+              active -= 1;
+              reject(err);
+              next();
+            },
+          );
+      };
+      if (active < limit) start();
+      else queue.push(start);
+    });
+}
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -65,7 +111,9 @@ async function telegramGetMe(botToken: string): Promise<{ ok: boolean; username?
     }
     return { ok: false, error: 'Invalid bot token' };
   } catch (error: unknown) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    // Issue #134: scrub bot token from any error message (URL or body) before
+    // it bubbles up to status payloads or logs.
+    return { ok: false, error: scrubBotToken(error instanceof Error ? error.message : String(error)) };
   }
 }
 
@@ -92,7 +140,8 @@ async function telegramGetUpdates(
     if (error instanceof Error && error.name === 'AbortError') {
       return { ok: false, updates: [], error: 'aborted' };
     }
-    return { ok: false, updates: [], error: error instanceof Error ? error.message : String(error) };
+    // Issue #134: scrub bot token from any error message before it surfaces.
+    return { ok: false, updates: [], error: scrubBotToken(error instanceof Error ? error.message : String(error)) };
   }
 }
 
@@ -106,6 +155,10 @@ export class GatewayRunner {
   private telegramPollers: Map<string, TelegramPollerState> = new Map();
   private running = false;
   private readonly platformRateLimiter = new PlatformRateLimiter();
+  // Issue #109: bound concurrent update handling so a 10-message burst does
+  // not serialize 10 LLM calls. 3 keeps Telegram from running out of typing
+  // indicators or hitting per-chat rate caps while still parallelising.
+  private readonly updateLimiter = createConcurrencyLimiter(3);
 
   constructor(config: GatewayRunnerConfig) {
     this.config = config;
@@ -181,7 +234,13 @@ export class GatewayRunner {
     const me = await telegramGetMe(botToken);
 
     if (!me.ok) {
-      const status: GatewayStatus = { platform: 'telegram', connected: false, error: me.error };
+      // Issue #134: scrub bot token from getMe error before storing in status —
+      // this string is returned by /api/gateway/status (a localhost-bypass route).
+      const status: GatewayStatus = {
+        platform: 'telegram',
+        connected: false,
+        error: me.error ? scrubBotToken(me.error) : me.error,
+      };
       this.statuses.set('telegram', status);
       return status;
     }
@@ -219,10 +278,12 @@ export class GatewayRunner {
       if (!poller.running || !this.running) break;
 
       if (!result.ok) {
-        // Update status with error but keep trying
+        // Update status with error but keep trying.
+        // Issue #134: scrub any leaked bot token from `result.error` before
+        // storing — this string is exposed by /api/gateway/status.
         const status = this.statuses.get('telegram');
         if (status && result.error !== 'aborted') {
-          status.error = result.error;
+          status.error = result.error ? scrubBotToken(result.error) : result.error;
         }
         // Back off on error
         await this.sleep(intervalMs * 3, poller.abortController.signal);
@@ -235,61 +296,83 @@ export class GatewayRunner {
         status.error = undefined;
       }
 
+      // Advance offset for every update synchronously so we don't re-fetch
+      // the same updates if a concurrent handler is still in flight when the
+      // next poll fires.
       for (const update of result.updates) {
-        // Advance offset past this update
         if (update.update_id !== undefined) {
           poller.offset = update.update_id + 1;
         }
-
-        const normalized = normalizeTelegramWebhook(update);
-        if (!normalized) continue;
-
-        if (this.config.onMessage) {
-          // Issue #102: Wrap the typing indicator in try/finally that spans
-          // BOTH onMessage AND the send path. Previously, `typing.stop()` was
-          // called immediately after onMessage resolved, leaving the indicator
-          // stopped while the send was still in flight (so the user saw
-          // "online, not typing" during a possibly-long retry). On the error
-          // path, the catch handler stopped it but did not protect the send
-          // call itself. The `finally` block guarantees the indicator is
-          // always stopped exactly once, regardless of where we exit.
-          const typing = createTypingIndicator(poller.botToken, normalized.channelId);
-          try {
-            const reply = await this.config.onMessage(normalized);
-            if (reply) {
-              // Per-platform rate limit check — delay instead of dropping
-              if (!this.platformRateLimiter.check('telegram')) {
-                const limit = this.platformRateLimiter.getLimit('telegram');
-                const delayMs = Math.ceil(60_000 / limit.maxPerMinute);
-                await this.sleep(delayMs, poller.abortController.signal);
-              }
-              // Retry with exponential backoff on send failure
-              const retryPolicy = buildGatewayRetryPolicy('telegram');
-              const result = await executeWithRetry(
-                () => sendTelegramMessage(poller.botToken, normalized.channelId, reply, { parseMode: 'Markdown' }),
-                retryPolicy,
-                poller.abortController.signal,
-              );
-              if (!result.ok) {
-                // Log retry exhaustion — reply is lost after all attempts failed
-                const errMsg = result.lastError ?? 'unknown';
-                try { await sendTelegramMessage(poller.botToken, normalized.channelId, 'Sorry, I encountered an error sending my response.', {}); } catch { /* best-effort fallback */ }
-                void errMsg; // Consumed by future structured logging integration
-              }
-            }
-          } catch {
-            // Silently handle callback or send errors to keep polling alive.
-            // The `finally` clause below stops the typing indicator either way.
-          } finally {
-            typing.stop();
-          }
-        }
       }
+
+      // Issue #109: handle the batch concurrently with bounded p-limit so a
+      // burst of 10 messages does not serialize 10 LLM calls. We still
+      // `await` the whole batch before returning to the polling cycle to
+      // preserve back-pressure against runaway provider failures.
+      await Promise.all(
+        result.updates.map((update) =>
+          this.updateLimiter(() => this.handleTelegramUpdate(poller, update)),
+        ),
+      );
 
       // Small interval between polls to avoid hammering
       if (result.updates.length === 0) {
         await this.sleep(intervalMs, poller.abortController.signal);
       }
+    }
+  }
+
+  /**
+   * Issue #109: per-update handler extracted so the polling loop can dispatch
+   * with `p-limit(3)`. Mirrors the previous inline body byte-for-byte (typing
+   * indicator semantics from #102 preserved).
+   */
+  private async handleTelegramUpdate(
+    poller: TelegramPollerState,
+    update: TelegramUpdate,
+  ): Promise<void> {
+    const normalized = normalizeTelegramWebhook(update);
+    if (!normalized) return;
+    if (!this.config.onMessage) return;
+
+    // Issue #102: Wrap the typing indicator in try/finally that spans
+    // BOTH onMessage AND the send path. Previously, `typing.stop()` was
+    // called immediately after onMessage resolved, leaving the indicator
+    // stopped while the send was still in flight (so the user saw
+    // "online, not typing" during a possibly-long retry). On the error
+    // path, the catch handler stopped it but did not protect the send
+    // call itself. The `finally` block guarantees the indicator is
+    // always stopped exactly once, regardless of where we exit.
+    const typing = createTypingIndicator(poller.botToken, normalized.channelId);
+    try {
+      const reply = await this.config.onMessage(normalized);
+      if (reply) {
+        // Per-platform rate limit check — delay instead of dropping
+        if (!this.platformRateLimiter.check('telegram')) {
+          const limit = this.platformRateLimiter.getLimit('telegram');
+          const delayMs = Math.ceil(60_000 / limit.maxPerMinute);
+          await this.sleep(delayMs, poller.abortController.signal);
+        }
+        // Retry with exponential backoff on send failure
+        const retryPolicy = buildGatewayRetryPolicy('telegram');
+        const sendResult = await executeWithRetry(
+          () => sendTelegramMessage(poller.botToken, normalized.channelId, reply, { parseMode: 'Markdown' }),
+          retryPolicy,
+          poller.abortController.signal,
+        );
+        if (!sendResult.ok) {
+          // Log retry exhaustion — reply is lost after all attempts failed.
+          // Issue #134: scrub any bot token that leaked into lastError.
+          const errMsg = scrubBotToken(sendResult.lastError ?? 'unknown');
+          try { await sendTelegramMessage(poller.botToken, normalized.channelId, 'Sorry, I encountered an error sending my response.', {}); } catch { /* best-effort fallback */ }
+          void errMsg; // Consumed by future structured logging integration
+        }
+      }
+    } catch {
+      // Silently handle callback or send errors to keep polling alive.
+      // The `finally` clause below stops the typing indicator either way.
+    } finally {
+      typing.stop();
     }
   }
 

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/learning",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,6 +17,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.0"
+    "@crowclaw/core": "0.6.1"
   }
 }

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.0"
+    "@crowclaw/core": "0.6.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/sandbox-executor": "0.6.0"
+    "@crowclaw/sandbox-executor": "0.6.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -118,6 +118,20 @@ export interface McpClientOptions {
   toolPrefix?: string;
   allowTools?: string[];
   denyTools?: string[];
+  /**
+   * Issue #80: Idle TTL for one-shot agent sessions. If set, the client tracks
+   * `lastUsedAt` on every `callTool` / `listTools` / `listResources` /
+   * `listPrompts` call and marks the session evictable once it has been idle
+   * for longer than this. Callers (or `MultiServerMcpManager.sweepIdle`) drive
+   * the actual eviction by calling {@link McpClient.sweepIfIdle} on a tick.
+   *
+   * Set to `0` or omit to disable idle eviction (default).
+   */
+  sessionIdleTtlMs?: number;
+  /**
+   * Issue #80: Override clock source for tests. Defaults to `Date.now`.
+   */
+  now?: () => number;
 }
 
 export class McpHttpTransport implements McpTransport {
@@ -181,11 +195,19 @@ export class McpClient {
   private degraded = false;
   private lastError?: string;
   private lastRefreshAt?: string;
+  /** Issue #80: epoch ms of last successful activity. */
+  private lastUsedAt: number;
+  /** Issue #80: set when sweepIfIdle/dispose has evicted this session. */
+  private disposed = false;
+  private readonly now: () => number;
 
   constructor(
     private readonly transport: McpTransport,
     private readonly options: McpClientOptions = {}
-  ) {}
+  ) {
+    this.now = options.now ?? Date.now;
+    this.lastUsedAt = this.now();
+  }
 
   static fromStdio(
     config: McpStdioServerConfig,
@@ -219,6 +241,7 @@ export class McpClient {
   }
 
   async refreshTools(): Promise<RegisteredMcpToolDefinition[]> {
+    this.ensureNotDisposed();
     try {
       const discovered = await this.transport.listTools();
       const registered = discovered
@@ -228,6 +251,7 @@ export class McpClient {
       this.degraded = false;
       this.lastError = undefined;
       this.lastRefreshAt = new Date().toISOString();
+      this.touch();
       return registered;
     } catch (error) {
       this.degraded = true;
@@ -260,18 +284,96 @@ export class McpClient {
   }
 
   async callTool(name: string, arguments_: Record<string, unknown>): Promise<McpCallResult> {
+    this.ensureNotDisposed();
     const resolvedName = await this.resolveToolName(name);
-    return this.transport.callTool(resolvedName, arguments_);
+    const result = await this.transport.callTool(resolvedName, arguments_);
+    this.touch();
+    return result;
   }
 
   async listResources(): Promise<RegisteredMcpResourceDefinition[]> {
+    this.ensureNotDisposed();
     const resources = await this.transport.listResources?.() ?? [];
+    this.touch();
     return resources.map((resource) => ({ ...resource }));
   }
 
   async listPrompts(): Promise<RegisteredMcpPromptDefinition[]> {
+    this.ensureNotDisposed();
     const prompts = await this.transport.listPrompts?.() ?? [];
+    this.touch();
     return prompts.map((prompt) => ({ ...prompt }));
+  }
+
+  // ------- Issue #80: idle session eviction -------
+
+  /** Issue #80: Update last-used timestamp. Called after every successful op. */
+  private touch(): void {
+    this.lastUsedAt = this.now();
+  }
+
+  /** Issue #80: Reject calls after `dispose()` has been invoked. */
+  private ensureNotDisposed(): void {
+    if (this.disposed) {
+      throw new Error('McpClient has been disposed (idle TTL exceeded).');
+    }
+  }
+
+  /** Issue #80: epoch ms of last successful activity. Exposed for diagnostics. */
+  getLastUsedAt(): number {
+    return this.lastUsedAt;
+  }
+
+  /** Issue #80: ms since the last successful op. */
+  getIdleMs(now: number = this.now()): number {
+    return now - this.lastUsedAt;
+  }
+
+  /** Issue #80: True after `dispose()` has been invoked. */
+  isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  /**
+   * Issue #80: Idle if `sessionIdleTtlMs` is set and `now - lastUsedAt`
+   * exceeds it. Sessions without a configured TTL are never idle.
+   */
+  isIdle(now: number = this.now()): boolean {
+    const ttl = this.options.sessionIdleTtlMs;
+    if (!ttl || ttl <= 0) return false;
+    return now - this.lastUsedAt > ttl;
+  }
+
+  /**
+   * Issue #80: If the session is idle (per `sessionIdleTtlMs`), dispose it and
+   * return true. Returns false otherwise. Drives eviction on a tick — call
+   * from a manager-level sweep loop.
+   */
+  async sweepIfIdle(now: number = this.now()): Promise<boolean> {
+    if (this.disposed) return false;
+    if (!this.isIdle(now)) return false;
+    await this.dispose();
+    return true;
+  }
+
+  /**
+   * Issue #80: Mark the client disposed and best-effort tear down the
+   * underlying transport. Idempotent. After dispose, all calls throw.
+   *
+   * Also invoked when a one-shot agent exits — see runtime wiring.
+   */
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.cachedTools = null;
+    const transport = this.transport as { disconnect?: () => Promise<void> };
+    if (typeof transport.disconnect === 'function') {
+      try {
+        await transport.disconnect();
+      } catch {
+        // Disconnect failures are non-fatal during eviction.
+      }
+    }
   }
 
   getStatus(): McpServerStatus {
@@ -435,5 +537,30 @@ export class MultiServerMcpManager {
       })
     );
     return Object.fromEntries(entries);
+  }
+
+  /**
+   * Issue #80: Sweep all managed clients and dispose any whose idle TTL has
+   * expired. Returns the names of evicted servers. Servers without a
+   * configured `sessionIdleTtlMs` are never evicted.
+   *
+   * Wire this on a manager-level interval (default 30s in callers) or call
+   * once from a one-shot agent's exit path to release child processes.
+   */
+  async sweepIdle(now?: number): Promise<string[]> {
+    const evicted: string[] = [];
+    for (const [serverName, client] of Object.entries(this.servers)) {
+      const swept = await client.sweepIfIdle(now);
+      if (swept) evicted.push(serverName);
+    }
+    return evicted;
+  }
+
+  /**
+   * Issue #80: Dispose every managed client. Used by one-shot agent exit and
+   * test teardown. Idempotent.
+   */
+  async disposeAll(): Promise<void> {
+    await Promise.all(Object.values(this.servers).map((client) => client.dispose()));
   }
 }

--- a/packages/mcp/src/stdio-transport.ts
+++ b/packages/mcp/src/stdio-transport.ts
@@ -19,6 +19,23 @@ export interface McpJsonRpcStdioTransportOptions {
   onStderr?: (data: string) => void;
   onClose?: (code: number | null) => void;
   onError?: (error: Error) => void;
+  /**
+   * Issue #103: Auto-reconnect on unexpected close. When true (default), the
+   * transport will schedule `connect()` after the child process closes
+   * unexpectedly, with exponential backoff (1s / 2s / 4s) up to
+   * `reconnectMaxAttempts` (default 3). Disabled automatically once
+   * `disconnect()` is called explicitly.
+   */
+  autoReconnect?: boolean;
+  /** Issue #103: Max reconnect attempts (default 3). */
+  reconnectMaxAttempts?: number;
+  /** Issue #103: Initial backoff delay in ms (default 1000). Doubles each attempt. */
+  reconnectInitialDelayMs?: number;
+  /**
+   * Issue #103: Hook fired before each reconnect attempt. Useful for tests
+   * and operator metrics.
+   */
+  onReconnect?: (attempt: number, delayMs: number) => void;
 }
 
 interface JsonRpcRequest {
@@ -49,12 +66,29 @@ export class McpJsonRpcStdioTransport implements McpTransport {
   private readonly onClose?: (code: number | null) => void;
   private readonly onError?: (error: Error) => void;
 
+  // ---- Issue #103: auto-reconnect state ----
+  private readonly autoReconnect: boolean;
+  private readonly reconnectMaxAttempts: number;
+  private readonly reconnectInitialDelayMs: number;
+  private readonly onReconnect?: (attempt: number, delayMs: number) => void;
+  /** Number of reconnect attempts since the last successful connect. */
+  private reconnectAttempt = 0;
+  /** Pending reconnect timer (if any). */
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Set to true by `disconnect()` to suppress further reconnect attempts. */
+  private disconnectRequested = false;
+
   constructor(config: McpStdioServerConfig, options?: McpJsonRpcStdioTransportOptions) {
     this.config = config;
     this.requestTimeoutMs = options?.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.onStderr = options?.onStderr;
     this.onClose = options?.onClose;
     this.onError = options?.onError;
+    // Issue #103: default autoReconnect = true. Backoff: 1s / 2s / 4s. Max 3.
+    this.autoReconnect = options?.autoReconnect ?? true;
+    this.reconnectMaxAttempts = options?.reconnectMaxAttempts ?? 3;
+    this.reconnectInitialDelayMs = options?.reconnectInitialDelayMs ?? 1000;
+    this.onReconnect = options?.onReconnect;
   }
 
   async connect(): Promise<void> {
@@ -89,9 +123,14 @@ export class McpJsonRpcStdioTransport implements McpTransport {
       this.connected = false;
       this.onClose?.(code);
       this.rejectAllPending(new Error(`MCP server process exited with code ${code}`));
+      // Issue #103: schedule reconnect with exponential backoff unless an
+      // explicit disconnect() was requested. Bound to `reconnectMaxAttempts`.
+      this.maybeScheduleReconnect();
     });
 
     this.connected = true;
+    // Issue #103: reset reconnect state on successful connect.
+    this.reconnectAttempt = 0;
 
     // Send MCP initialize request
     await this.sendRequest('initialize', {
@@ -107,7 +146,47 @@ export class McpJsonRpcStdioTransport implements McpTransport {
     this.sendNotification('notifications/initialized', {});
   }
 
+  /**
+   * Issue #103: Schedule a reconnect attempt after unexpected close. No-op when
+   * autoReconnect is disabled, the consumer requested disconnect, or we have
+   * exhausted attempts. Backoff is `initialDelay * 2^attempt`.
+   */
+  private maybeScheduleReconnect(): void {
+    if (!this.autoReconnect) return;
+    if (this.disconnectRequested) return;
+    if (this.reconnectAttempt >= this.reconnectMaxAttempts) return;
+    if (this.reconnectTimer) return; // already scheduled
+
+    const attempt = this.reconnectAttempt + 1;
+    const delayMs = this.reconnectInitialDelayMs * Math.pow(2, this.reconnectAttempt);
+    this.reconnectAttempt = attempt;
+    this.onReconnect?.(attempt, delayMs);
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      // The connect() call resets `reconnectAttempt` on success and the close
+      // handler will re-trigger this method on subsequent failures, capping at
+      // `reconnectMaxAttempts`.
+      void this.connect().catch((error: unknown) => {
+        this.onError?.(error instanceof Error ? error : new Error(String(error)));
+      });
+    }, delayMs);
+    // Issue #126 follow-on: don't keep the event loop alive solely to
+    // retry — agents may exit while a backoff is pending.
+    if (typeof this.reconnectTimer === 'object' && this.reconnectTimer !== null) {
+      (this.reconnectTimer as { unref?: () => void }).unref?.();
+    }
+  }
+
   async disconnect(): Promise<void> {
+    // Issue #103: mark explicit disconnect *first* so any in-flight close
+    // handler (race with SIGTERM) suppresses the reconnect schedule.
+    this.disconnectRequested = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
     if (!this.connected || !this.childProcess) {
       return;
     }

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/memory",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.0",
-    "@crowclaw/storage": "0.6.0"
+    "@crowclaw/core": "0.6.1",
+    "@crowclaw/storage": "0.6.1"
   }
 }

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -219,10 +219,15 @@ export { UserModelService, type UserProfile } from './user-model.js';
 export {
   type MemoryRecord as ManagerMemoryRecord,
   type MemoryProvider,
+  type SessionTranscriptMessage,
   BuiltInMemoryProvider,
   EmbeddingMemoryProvider,
 } from './memory-provider.js';
-export { MemoryManager, SKIP_REDACTION_FLAG } from './memory-manager.js';
+export {
+  MemoryManager,
+  SKIP_REDACTION_FLAG,
+  type SessionEndResult,
+} from './memory-manager.js';
 export {
   FrozenMemory,
   InMemoryFrozenStore,

--- a/packages/memory/src/memory-manager.ts
+++ b/packages/memory/src/memory-manager.ts
@@ -1,5 +1,24 @@
 import { redactStructuredData } from '@crowclaw/core';
-import type { MemoryProvider, MemoryRecord } from './memory-provider.js';
+import type {
+  MemoryProvider,
+  MemoryRecord,
+  SessionTranscriptMessage,
+} from './memory-provider.js';
+
+/**
+ * Per-provider outcome reported by `MemoryManager.shutdown`. Hosts can log
+ * failures without losing the rest of the fan-out result. (#85)
+ */
+export interface SessionEndResult {
+  /** Provider name as reported by `MemoryProvider.name`. */
+  provider: string;
+  /** Whether the provider's `onSessionEnd` ran (false when the hook was unset). */
+  invoked: boolean;
+  /** Whether the hook completed without throwing. */
+  ok: boolean;
+  /** Error message when `ok === false`. */
+  error?: string;
+}
 
 /**
  * Metadata flag that opts a single `store()` call out of credential
@@ -80,6 +99,42 @@ export class MemoryManager {
     const deduped = this.deduplicateByKey(merged);
 
     return deduped.slice(0, limit);
+  }
+
+  /**
+   * Fan a session-end transcript out to every provider's optional
+   * `onSessionEnd` hook. Issue #85 — previously the host passed `[]` here,
+   * which silently disabled dream-memory live capture and end-of-session
+   * summarisation. Callers MUST pass the live `session.messages` array.
+   *
+   * Errors are caught per-provider so a single failing backend does not
+   * abort the rest of the fan-out. Returns one `SessionEndResult` per
+   * registered provider, in registration order.
+   */
+  async shutdown(
+    sessionId: string,
+    messages: SessionTranscriptMessage[],
+  ): Promise<SessionEndResult[]> {
+    if (!Array.isArray(messages)) {
+      // Defensive: a host bug that passes `null`/`undefined` should not
+      // crash shutdown, but we surface it via an empty-transcript result so
+      // the issue is observable in logs.
+      messages = [];
+    }
+    return Promise.all(
+      this.providers.map(async (provider): Promise<SessionEndResult> => {
+        if (typeof provider.onSessionEnd !== 'function') {
+          return { provider: provider.name, invoked: false, ok: true };
+        }
+        try {
+          await provider.onSessionEnd(sessionId, messages);
+          return { provider: provider.name, invoked: true, ok: true };
+        } catch (err: unknown) {
+          const error = err instanceof Error ? err.message : String(err);
+          return { provider: provider.name, invoked: true, ok: false, error };
+        }
+      }),
+    );
   }
 
   /** Remove a key from ALL providers. Returns true if at least one provider removed it. */

--- a/packages/memory/src/memory-provider.ts
+++ b/packages/memory/src/memory-provider.ts
@@ -15,14 +15,43 @@ export interface MemoryRecord {
 }
 
 /**
+ * Minimal transcript shape consumed by `MemoryProvider.onSessionEnd`. Mirrors
+ * `ConversationMessage` from `@crowclaw/core` but is intentionally restated
+ * here so the memory package stays free of a runtime dep on core. Hosts can
+ * pass `session.messages` directly.
+ */
+export interface SessionTranscriptMessage {
+  role: string;
+  content: string;
+  createdAt?: string;
+  toolCallId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
  * Pluggable memory backend. Implementations wrap a concrete storage mechanism
  * (in-memory map, embedding index, external DB, etc.) behind a uniform interface.
+ *
+ * Issue #85 — `onSessionEnd` is the canonical hook for end-of-session memory
+ * consolidation (dream-memory live capture, session-summary writes, FTS
+ * indexing). Hosts MUST pass the actual `session.messages` transcript here,
+ * not `[]`. Previously some call sites passed an empty array, which silently
+ * disabled summarisation. Implementations that don't need transcripts can
+ * leave the hook unset.
  */
 export interface MemoryProvider {
   name: string;
   store(key: string, content: string, metadata?: Record<string, unknown>): Promise<void>;
   recall(query: string, limit?: number): Promise<MemoryRecord[]>;
   forget(key: string): Promise<boolean>;
+  /**
+   * Optional end-of-session hook. The host calls this with the full
+   * conversation transcript when a session terminates so the provider can
+   * persist a summary, embed the transcript, etc. Errors thrown here are
+   * caught by `MemoryManager.shutdown` and reported per-provider so one
+   * failing backend cannot abort the rest of the fan-out.
+   */
+  onSessionEnd?(sessionId: string, messages: SessionTranscriptMessage[]): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/plugins",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,6 +17,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.0"
+    "@crowclaw/core": "0.6.1"
   }
 }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -11,10 +11,12 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@crowclaw/core": "0.6.0"
   }
 }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -1,183 +1,25 @@
-export interface PluginContext {
-  runtime: string;
-  sessionId: string;
-  agentId: string;
-}
-
 /**
- * #95: Plugin can veto a tool call before execution.
- * Return `{ veto: true, reason }` to block; return `{ veto: false }` (or
- * undefined / void) to allow. The agent loop OR-aggregates across plugins:
- * any single veto blocks the call.
- */
-export interface PreToolCallVeto {
-  veto: boolean;
-  reason?: string;
-}
-
-/**
- * #95: Plugin can transform a tool result after execution but before the
- * agent loop appends it to conversation history. Return a partial override
- * (only the fields you want to change) or undefined to leave it untouched.
+ * Backward-compat shim for `@crowclaw/plugins`.
  *
- * Note: this runs *after* core's redaction + injection-scan layer, so plugins
- * see the already-redacted output. They cannot un-redact.
+ * Issue #158 moved the canonical plugin contract + `PluginManager` into
+ * `@crowclaw/core` to fix the layering inversion (core was depending on
+ * plugins). Existing consumers that import from `@crowclaw/plugins` keep
+ * working — every symbol below is a re-export from core.
+ *
+ * New code should prefer `import { PluginManager, ... } from '@crowclaw/core'`.
  */
-export interface ToolResultTransform {
-  output?: string;
-  ok?: boolean;
-  metadata?: Record<string, unknown>;
-}
 
-export interface PluginHookPayloads {
-  'agent:beforeRun': { input: { agentId: string; sessionId: string; [key: string]: unknown } };
-  'agent:afterRun': { input: { agentId: string; sessionId: string; [key: string]: unknown }; result: { finalResponse: string; toolResults: Array<{ toolName: string; ok: boolean }> } };
-  'provider:beforeGenerate': { attempt: number; providerIndex: number; messageCount: number };
-  'provider:afterGenerate': { attempt: number; providerIndex: number; messageCount: number; toolCallCount: number; assistantMessage?: string };
-  'provider:error': { attempt: number; providerIndex: number; messageCount: number; error: string };
-  'tool:beforeExecute': { toolName: string; input: Record<string, unknown>; sessionId: string; agentId: string };
-  'tool:result': { result: { toolName: string; ok: boolean; output: string }; sessionId: string; agentId: string };
-  'tool:error': { result: { toolName: string; ok: boolean; output: string }; sessionId: string; agentId: string };
-}
-
-/**
- * #95: Hooks that *return* a value (veto / transform) are kept separate from
- * the fire-and-forget `on` hooks so their signatures can encode return types
- * cleanly. Plugins implement only the methods they care about.
- */
-export interface PluginInvocationPayloads {
-  /** Pre-execution gate. Plugins return `{veto:true,reason}` to block. */
-  'tool:preExecute': {
-    payload: { toolName: string; input: Record<string, unknown>; sessionId: string; agentId: string };
-    result: PreToolCallVeto | void;
-  };
-  /** Post-execution transform. Plugins return a partial override of the tool result. */
-  'tool:transformResult': {
-    payload: {
-      toolName: string;
-      input: Record<string, unknown>;
-      result: { toolName: string; ok: boolean; output: string; metadata?: Record<string, unknown> };
-      sessionId: string;
-      agentId: string;
-    };
-    result: ToolResultTransform | void;
-  };
-}
-
-export type PluginHookName = keyof PluginHookPayloads;
-export type PluginInvocationName = keyof PluginInvocationPayloads;
-
-export interface Plugin {
-  name: string;
-  /** Fire-and-forget observer hooks. */
-  on?<K extends PluginHookName>(hook: K, payload: PluginHookPayloads[K], context: PluginContext): Promise<void> | void;
-  /**
-   * #95: Pre-execution veto. Return `{veto:true,reason}` to block this tool
-   * call. Multiple plugins are OR-aggregated: any veto blocks. Throwing here
-   * is treated as a non-vetoing error and logged; it never blocks.
-   */
-  preToolCall?(
-    payload: PluginInvocationPayloads['tool:preExecute']['payload'],
-    context: PluginContext,
-  ): Promise<PreToolCallVeto | void> | PreToolCallVeto | void;
-  /**
-   * #95: Post-execution transform. Return a partial override of the result
-   * (any field you don't return is preserved). Plugins are applied in
-   * registration order; later plugins see the output of earlier ones.
-   * Throwing here passes the previous result through unchanged.
-   */
-  transformToolResult?(
-    payload: PluginInvocationPayloads['tool:transformResult']['payload'],
-    context: PluginContext,
-  ): Promise<ToolResultTransform | void> | ToolResultTransform | void;
-}
-
-export class PluginManager {
-  private readonly plugins = new Map<string, Plugin>();
-
-  register(plugin: Plugin): this {
-    this.plugins.set(plugin.name, plugin);
-    return this;
-  }
-
-  list(): Plugin[] {
-    return [...this.plugins.values()];
-  }
-
-  async emit<K extends PluginHookName>(hook: K, payload: PluginHookPayloads[K], context: PluginContext): Promise<void> {
-    for (const plugin of this.plugins.values()) {
-      await plugin.on?.(hook, payload, context);
-    }
-  }
-
-  /**
-   * #95: Run pre-tool-call gates across all plugins. OR-aggregates: the first
-   * `veto:true` short-circuits and is returned. Plugin throws are caught and
-   * treated as non-vetoing (we don't want a buggy plugin to lock out tools).
-   */
-  async preToolCall(
-    payload: PluginInvocationPayloads['tool:preExecute']['payload'],
-    context: PluginContext,
-  ): Promise<PreToolCallVeto> {
-    for (const plugin of this.plugins.values()) {
-      if (!plugin.preToolCall) continue;
-      try {
-        const verdict = await plugin.preToolCall(payload, context);
-        if (verdict && verdict.veto) {
-          return {
-            veto: true,
-            reason: verdict.reason ? `${plugin.name}: ${verdict.reason}` : `${plugin.name}: vetoed`,
-          };
-        }
-      } catch (error) {
-        // Buggy plugin must not block tools — log and continue.
-        // (We don't have a logger here; best the manager can do is swallow.)
-        void error;
-      }
-    }
-    return { veto: false };
-  }
-
-  /**
-   * #95: Run post-tool-call transforms across all plugins. Each plugin sees
-   * the output of the previous transform; returning `void`/undefined leaves
-   * the running result unchanged. Plugin throws revert to the prior result.
-   */
-  async transformToolResult(
-    payload: PluginInvocationPayloads['tool:transformResult']['payload'],
-    context: PluginContext,
-  ): Promise<{ toolName: string; ok: boolean; output: string; metadata?: Record<string, unknown> }> {
-    let current = payload.result;
-    for (const plugin of this.plugins.values()) {
-      if (!plugin.transformToolResult) continue;
-      try {
-        const transform = await plugin.transformToolResult(
-          { ...payload, result: current },
-          context,
-        );
-        if (!transform) continue;
-        current = {
-          toolName: current.toolName,
-          ok: transform.ok ?? current.ok,
-          output: transform.output ?? current.output,
-          metadata: transform.metadata
-            ? { ...(current.metadata ?? {}), ...transform.metadata }
-            : current.metadata,
-        };
-      } catch (error) {
-        // Plugin error: keep prior result, continue with the next plugin.
-        void error;
-      }
-    }
-    return current;
-  }
-}
-
-export class MemoryCapturePlugin implements Plugin {
-  readonly name = 'memory-capture';
-  public seen: Array<{ hook: PluginHookName; sessionId: string }> = [];
-
-  async on<K extends PluginHookName>(hook: K, _payload: PluginHookPayloads[K], context: PluginContext): Promise<void> {
-    this.seen.push({ hook, sessionId: context.sessionId });
-  }
-}
+export {
+  PluginManager,
+  MemoryCapturePlugin,
+} from '@crowclaw/core';
+export type {
+  Plugin,
+  PluginContext,
+  PluginHookName,
+  PluginHookPayloads,
+  PluginInvocationName,
+  PluginInvocationPayloads,
+  PreToolCallVeto,
+  ToolResultTransform,
+} from '@crowclaw/core';

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/providers",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,6 +17,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.0"
+    "@crowclaw/core": "0.6.1"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -2347,6 +2347,14 @@ export type {
   ManifestCacheEntry,
 } from './model-catalog.js';
 
+// Issue #81: Plugin manifest cold-read for fast startup
+export {
+  hasPluginManifestModelCatalog,
+  readPluginManifestModelCatalog,
+  seedManifestCacheFromPlugin,
+} from './model-catalog.js';
+export type { PluginManifestModelCatalog } from './model-catalog.js';
+
 // Issue #61: Local embedding provider with tunable context size
 export { LocalEmbeddingProvider } from './local-embedding-provider.js';
 export type { LocalEmbeddingProviderConfig } from './local-embedding-provider.js';

--- a/packages/providers/src/model-catalog.ts
+++ b/packages/providers/src/model-catalog.ts
@@ -243,3 +243,102 @@ export function resolveContextLengthFromManifest(
   const entry = findModelEntry(manifest, modelId);
   return entry?.contextLength ?? fallback;
 }
+
+// ---------------------------------------------------------------------------
+// Issue #81: Plugin manifest cold-read
+// ---------------------------------------------------------------------------
+
+/**
+ * Issue #81: Minimal shape of the `modelCatalog` block expected on a plugin
+ * manifest. Plugins (declared in `packages/plugins/src/contracts.ts`, owned by
+ * a sibling team) ship this so the runtime can hydrate context-length
+ * lookups *cold* — without paying the round-trip to the remote manifest URL
+ * during startup.
+ *
+ * The shape is intentionally a strict subset of {@link ModelManifest}: every
+ * model entry must include the same flags so cached lookups (vision/tools/
+ * streaming caps) work identically whether they came from cold-read or
+ * remote fetch.
+ */
+export interface PluginManifestModelCatalog {
+  /** ISO date string. Used as the manifest's updatedAt when seeded. */
+  updatedAt?: string;
+  models: ModelManifestEntry[];
+}
+
+/**
+ * Issue #81: Type guard for a plugin manifest carrying a `modelCatalog` block.
+ * Accepts unknown input so callers can pass raw JSON without pre-validation.
+ */
+export function hasPluginManifestModelCatalog(
+  manifest: unknown,
+): manifest is { modelCatalog: PluginManifestModelCatalog } {
+  if (!manifest || typeof manifest !== 'object') return false;
+  const candidate = (manifest as { modelCatalog?: unknown }).modelCatalog;
+  if (!candidate || typeof candidate !== 'object') return false;
+  const catalog = candidate as Partial<PluginManifestModelCatalog>;
+  return Array.isArray(catalog.models);
+}
+
+/**
+ * Issue #81: Convert a plugin manifest's `modelCatalog` block into the shared
+ * {@link ModelManifest} shape. Defensive — invalid entries are filtered out so
+ * a malformed plugin manifest cannot crash provider startup. Returns null when
+ * the plugin has no usable catalog.
+ */
+export function readPluginManifestModelCatalog(
+  manifest: unknown,
+): ModelManifest | null {
+  if (!hasPluginManifestModelCatalog(manifest)) return null;
+  const catalog = manifest.modelCatalog;
+  const models: ModelManifestEntry[] = [];
+  for (const raw of catalog.models) {
+    if (!raw || typeof raw !== 'object') continue;
+    const m = raw as Partial<ModelManifestEntry>;
+    if (typeof m.id !== 'string') continue;
+    if (typeof m.contextLength !== 'number' || !Number.isFinite(m.contextLength)) continue;
+    if (typeof m.supportsTools !== 'boolean') continue;
+    if (typeof m.supportsImages !== 'boolean') continue;
+    if (typeof m.supportsStreaming !== 'boolean') continue;
+    models.push({
+      id: m.id,
+      contextLength: m.contextLength,
+      supportsTools: m.supportsTools,
+      supportsImages: m.supportsImages,
+      supportsStreaming: m.supportsStreaming,
+    });
+  }
+  if (models.length === 0) return null;
+  return {
+    updatedAt: typeof catalog.updatedAt === 'string' ? catalog.updatedAt : new Date().toISOString().slice(0, 10),
+    models,
+  };
+}
+
+/**
+ * Issue #81: Seed the in-memory manifest cache from a plugin's `modelCatalog`
+ * for the given URL key (defaulting to {@link DEFAULT_MANIFEST_URL}). Use this
+ * during runtime startup so the *first* `loadManifest` call serves from cache
+ * with no network round-trip. Subsequent calls past the 24h TTL still
+ * revalidate against the remote URL.
+ *
+ * Returns true when a catalog was seeded, false when the manifest had no
+ * usable `modelCatalog` block.
+ */
+export function seedManifestCacheFromPlugin(
+  manifest: unknown,
+  options?: { url?: string; cache?: ManifestCache; now?: () => number },
+): boolean {
+  const seeded = readPluginManifestModelCatalog(manifest);
+  if (!seeded) return false;
+  const cache = options?.cache ?? defaultCache;
+  const url = options?.url ?? DEFAULT_MANIFEST_URL;
+  const now = options?.now ?? Date.now;
+  cache.set(url, {
+    manifest: seeded,
+    fetchedAt: now(),
+    // No etag — a remote 304 path won't trigger; next 24h-expiry refetch will
+    // populate one.
+  });
+  return true;
+}

--- a/packages/runtime-cloudflare/package.json
+++ b/packages/runtime-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/runtime-cloudflare",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,18 +18,18 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.8.9",
-    "@crowclaw/core": "0.6.0",
-    "@crowclaw/memory": "0.6.0",
-    "@crowclaw/providers": "0.6.0",
-    "@crowclaw/sandbox-executor": "0.6.0",
-    "@crowclaw/shared": "0.6.0",
-    "@crowclaw/storage": "0.6.0",
-    "@crowclaw/tools": "0.6.0",
-    "@crowclaw/gateway": "0.6.0",
-    "@crowclaw/workspace": "0.6.0",
-    "@crowclaw/learning": "0.6.0",
-    "@crowclaw/mcp": "0.6.0",
-    "@crowclaw/scheduler": "0.6.0",
-    "@crowclaw/plugins": "0.6.0"
+    "@crowclaw/core": "0.6.1",
+    "@crowclaw/memory": "0.6.1",
+    "@crowclaw/providers": "0.6.1",
+    "@crowclaw/sandbox-executor": "0.6.1",
+    "@crowclaw/shared": "0.6.1",
+    "@crowclaw/storage": "0.6.1",
+    "@crowclaw/tools": "0.6.1",
+    "@crowclaw/gateway": "0.6.1",
+    "@crowclaw/workspace": "0.6.1",
+    "@crowclaw/learning": "0.6.1",
+    "@crowclaw/mcp": "0.6.1",
+    "@crowclaw/scheduler": "0.6.1",
+    "@crowclaw/plugins": "0.6.1"
   }
 }

--- a/packages/runtime-cloudflare/package.json
+++ b/packages/runtime-cloudflare/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -27,8 +27,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/runtime-node",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -33,18 +33,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/acp": "0.6.0",
-    "@crowclaw/core": "0.6.0",
-    "@crowclaw/gateway": "0.6.0",
-    "@crowclaw/learning": "0.6.0",
-    "@crowclaw/mcp": "0.6.0",
-    "@crowclaw/mcp-server": "0.6.0",
-    "@crowclaw/memory": "0.6.0",
-    "@crowclaw/plugins": "0.6.0",
-    "@crowclaw/providers": "0.6.0",
-    "@crowclaw/scheduler": "0.6.0",
-    "@crowclaw/storage": "0.6.0",
-    "@crowclaw/tools": "0.6.0",
-    "@crowclaw/workspace": "0.6.0"
+    "@crowclaw/acp": "0.6.1",
+    "@crowclaw/core": "0.6.1",
+    "@crowclaw/gateway": "0.6.1",
+    "@crowclaw/learning": "0.6.1",
+    "@crowclaw/mcp": "0.6.1",
+    "@crowclaw/mcp-server": "0.6.1",
+    "@crowclaw/memory": "0.6.1",
+    "@crowclaw/plugins": "0.6.1",
+    "@crowclaw/providers": "0.6.1",
+    "@crowclaw/scheduler": "0.6.1",
+    "@crowclaw/storage": "0.6.1",
+    "@crowclaw/tools": "0.6.1",
+    "@crowclaw/workspace": "0.6.1"
   }
 }

--- a/packages/runtime-node/src/bridge-process.ts
+++ b/packages/runtime-node/src/bridge-process.ts
@@ -12,12 +12,16 @@ export interface BridgeProcessRecord {
   exitedAt?: string;
   exitCode?: number | null;
   spawnError?: string;
+  // #123: `removeAllListeners` is called on the handle during termination so
+  //       the child process's event listeners (and their captured closures)
+  //       can be released.
   handle?: {
     pid?: number;
     kill(signal?: string): boolean;
     unref?: () => void;
     on?: (event: string, callback: (code: number | null) => void) => void;
-  };
+    removeAllListeners?: (event?: string) => void;
+  } | null;
 }
 
 export async function ensureBridgeProcess(
@@ -441,5 +445,65 @@ export function terminateBridgeProcess(
   record.alive = false;
   record.socketReady = false;
   record.exitedAt = new Date().toISOString();
+  // #123: Detach all event listeners we registered on the child handle and
+  //       null the handle itself. The 'exit' listener captures `record`,
+  //       which keeps the entry retained even after the child has exited.
+  //       Combined with the `processes.delete(sessionId)` below this lets
+  //       the GC reclaim both the handle and the closure.
+  if (record.handle?.removeAllListeners) {
+    try { record.handle.removeAllListeners(); } catch { /* best-effort */ }
+  }
+  record.handle = null;
+  // #116: Drop the Map entry. Long-running runtimes accumulate dead
+  //       BridgeProcessRecords (each holding a transcript + spawn metadata)
+  //       because previously terminate() only flipped `alive=false` and
+  //       `pruneStaleBridgeSessions` only operated on `codeBridgeSessions`.
+  processes.delete(sessionId);
   return record;
+}
+
+/**
+ * #116: Drop dead or stale bridge process records. Companion to
+ * `pruneStaleBridgeSessions` (in `bridge-state.ts`) which only handles the
+ * transcript-side `codeBridgeSessions` Map; this function targets the
+ * `bridgeProcesses` Map which holds the spawned-child metadata.
+ *
+ * Removes entries that are either:
+ *   - already marked `alive = false` (terminated but never deleted), OR
+ *   - older than `maxAgeMs` based on `startedAt`.
+ *
+ * Returns the number of entries removed.
+ */
+export function pruneDeadBridgeProcesses(
+  processes: Map<string, BridgeProcessRecord>,
+  maxAgeMs: number = 60 * 60 * 1000, // 1h, mirrors session prune default
+  now: number = Date.now(),
+): number {
+  let removed = 0;
+  for (const [key, record] of processes) {
+    // Only drop records that ACTUALLY ran and then exited (have `exitedAt`).
+    // Simulated / spawn-error records (alive=false from birth) stay visible
+    // to operators — they're the only signal that a bridge failed to spawn,
+    // and aggressively pruning them silently swallows the diagnostic.
+    if (!record.alive && record.exitedAt) {
+      processes.delete(key);
+      removed++;
+      continue;
+    }
+    const ts = new Date(record.startedAt).getTime();
+    if (!Number.isFinite(ts)) continue;
+    if (now - ts > maxAgeMs) {
+      // Best-effort terminate so we don't leave a zombie child handle.
+      if (record.handle?.kill) {
+        try { record.handle.kill('SIGTERM'); } catch { /* best-effort */ }
+      }
+      if (record.handle?.removeAllListeners) {
+        try { record.handle.removeAllListeners(); } catch { /* best-effort */ }
+      }
+      record.handle = null;
+      processes.delete(key);
+      removed++;
+    }
+  }
+  return removed;
 }

--- a/packages/runtime-node/src/index.ts
+++ b/packages/runtime-node/src/index.ts
@@ -60,6 +60,7 @@ import {
   setTelegramWebhook,
   deleteTelegramWebhook,
   getTelegramWebhookInfo,
+  WsAuthRateLimiter,
 } from '@crowclaw/gateway';
 import { LearningPipeline, InMemorySkillStore, getBuiltInSkills, SkillRegistry, createLlmSkillExtractor } from '@crowclaw/learning';
 import { McpClient, McpHttpTransport, listMcpPresetNames, getMcpPresetDescription, verifyPresetAvailability } from '@crowclaw/mcp';
@@ -77,7 +78,7 @@ import { RuntimeConfigStore, FileConfigStore } from './config-store.js';
 import { pruneStaleBridgeSessions, type CodeBridgeSession } from './bridge-state.js';
 import { ensureBrowserSession, pruneStaleBrowserSessions, recordBrowserNavigation, type BrowserSessionState } from './browser-state.js';
 import { handleCodeBridgeRoutes } from './bridge-routes.js';
-import type { BridgeProcessRecord } from './bridge-process.js';
+import { pruneDeadBridgeProcesses, type BridgeProcessRecord } from './bridge-process.js';
 import { routePaths } from './route-paths.js';
 import { resolveProviderFromConfig, resolveProvidersFromConfig, createProviderFromSlot } from './provider-factory.js';
 import { SessionController } from './session-controller.js';
@@ -160,6 +161,27 @@ export class GatewayDebouncer {
   /** Number of keys currently pending debounce */
   get pendingCount(): number {
     return this.pending.size;
+  }
+
+  /**
+   * #120: Drain all pending debounce timers. Called from `shutdown()` so
+   * pending timers and their resolve closures don't leak between runtime
+   * lifetimes. Each pending caller resolves with whatever messages were
+   * already accumulated (rather than rejecting) so awaiting code in the
+   * gateway routes returns deterministically and any partially-merged
+   * text still flows through downstream chat handling instead of being
+   * silently dropped.
+   *
+   * Returns the number of pending entries that were flushed.
+   */
+  flush(): number {
+    const drained = this.pending.size;
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+      try { entry.resolve(entry.messages.join('\n')); } catch { /* swallow */ }
+    }
+    this.pending.clear();
+    return drained;
   }
 }
 
@@ -801,9 +823,14 @@ function normalizeIp(ip: string): string {
  * O(N) copy on every check; this is O(expired) with no allocation in the
  * common steady-state path.
  */
-class RateLimiter {
+export class RateLimiter {
   private requests = new Map<string, number[]>();
   private readonly maxKeys: number;
+
+  /** Exposed for tests / observability — not part of the public hot path. */
+  get size(): number {
+    return this.requests.size;
+  }
 
   constructor(options?: { maxKeys?: number }) {
     this.maxKeys = options?.maxKeys ?? 50_000;
@@ -828,12 +855,142 @@ class RateLimiter {
       return false; // rate limited
     }
     timestamps.push(now); // monotonic — preserves sorted order
-    // Evict oldest entry if at capacity (prevents unbounded memory growth)
+    // Evict oldest entry if at capacity (prevents unbounded memory growth).
+    // #124: When the oldest key IS the current key (e.g. the inserted key
+    // is the only one, or it happens to be at the head of the insertion
+    // order), the previous guard `oldest !== key` skipped eviction entirely
+    // and the Map size grew to maxKeys + 1 — and would compound the further
+    // distinct keys arrived. Walk forward instead so we always free a slot
+    // when over capacity, and never evict the entry we just inserted.
     if (this.requests.size > this.maxKeys) {
-      const oldest = this.requests.keys().next().value;
-      if (oldest !== undefined && oldest !== key) this.requests.delete(oldest);
+      for (const candidate of this.requests.keys()) {
+        if (candidate !== key) {
+          this.requests.delete(candidate);
+          break;
+        }
+      }
     }
     return true; // allowed
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Body size cap (#128) — defends against memory-exhaustion via large POSTs
+// ---------------------------------------------------------------------------
+
+/** Max accepted JSON body, in bytes. 1 MiB matches typical reverse-proxy
+ *  defaults and is far above any legitimate dashboard / gateway payload —
+ *  the largest realistic body is a multi-thousand-token chat message which
+ *  fits comfortably in tens of kilobytes. Anything larger almost certainly
+ *  represents an abusive caller or a misconfigured client.
+ */
+export const MAX_REQUEST_BODY_BYTES = 1_048_576;
+
+/**
+ * Inspect `Content-Length` and reject oversized bodies before they're buffered
+ * in memory. Returns `null` when the request is acceptable, or a 413 Response
+ * when the declared length exceeds the cap. Callers should still read with
+ * `readJsonWithSizeCap` to defend against chunked / unknown-length bodies that
+ * omit the header.
+ */
+export function checkContentLengthCap(request: Request, max: number = MAX_REQUEST_BODY_BYTES): Response | null {
+  const raw = request.headers.get('content-length');
+  if (raw === null) return null;
+  const declared = Number(raw);
+  if (!Number.isFinite(declared) || declared < 0) {
+    // Malformed header — treat as suspicious. Reject rather than guessing.
+    return Response.json({ error: 'invalid content-length' }, { status: 400 });
+  }
+  if (declared > max) {
+    return Response.json(
+      { error: 'request body too large', maxBytes: max },
+      { status: 413, headers: { 'Connection': 'close' } },
+    );
+  }
+  return null;
+}
+
+/**
+ * Parse a JSON body with a hard size cap. Defensive about chunked transfers
+ * that omit `Content-Length`: streams the body through a manual byte counter
+ * and aborts as soon as the cap is exceeded. This avoids `request.json()`
+ * loading a 1 GB payload into memory before validation could possibly run.
+ *
+ * On success returns `{ ok: true, value }`. On overflow / malformed JSON
+ * returns `{ ok: false, response }` with the appropriate 413 / 400 response
+ * the caller can return directly.
+ */
+export async function readJsonWithSizeCap<T = unknown>(
+  request: Request,
+  max: number = MAX_REQUEST_BODY_BYTES,
+): Promise<{ ok: true; value: T } | { ok: false; response: Response }> {
+  // 1) Cheap header check first — rejects the obvious abuse without ever
+  //    touching the body stream.
+  const headerReject = checkContentLengthCap(request, max);
+  if (headerReject) return { ok: false, response: headerReject };
+
+  // 2) Stream body chunks through a size accumulator. We can't trust
+  //    Content-Length on chunked transfers, so this is the real gate.
+  const body = request.body;
+  if (!body) {
+    return { ok: true, value: {} as T };
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > max) {
+        // Cancel the upstream stream so we don't keep buffering a hostile
+        // sender's bytes after we've already decided to reject.
+        try { await reader.cancel('body too large'); } catch { /* best-effort */ }
+        return {
+          ok: false,
+          response: Response.json(
+            { error: 'request body too large', maxBytes: max },
+            { status: 413, headers: { 'Connection': 'close' } },
+          ),
+        };
+      }
+      chunks.push(value);
+    }
+  } catch (err: unknown) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'failed to read request body', detail: err instanceof Error ? err.message : String(err) },
+        { status: 400 },
+      ),
+    };
+  }
+
+  if (total === 0) {
+    return { ok: true, value: {} as T };
+  }
+
+  // Reassemble chunks into a single Uint8Array, then decode + parse.
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.byteLength;
+  }
+  const text = new TextDecoder('utf-8').decode(merged);
+  try {
+    return { ok: true, value: JSON.parse(text) as T };
+  } catch (err: unknown) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'invalid JSON', detail: err instanceof Error ? err.message : String(err) },
+        { status: 400 },
+      ),
+    };
   }
 }
 
@@ -1238,6 +1395,11 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
   // Context engine: discover .crowclaw.md, AGENTS.md, CLAUDE.md from working dir
   let contextEngineResult: ContextEngineResult | null = null;
   let contextEngineReady: Promise<void> = Promise.resolve();
+  // #119: Hoist the refresh handle so `shutdown()` can clear it. Without this
+  // two consecutive `createNodeRuntime({ workingDirectory })` calls leave a
+  // stray 60s interval ticking against the previous engine's closure (each
+  // capture pins a ContextEngine instance + its workingDir state).
+  let contextRefresh: ReturnType<typeof setInterval> | null = null;
   // Context discovery: only when workingDirectory is explicitly provided in options
   // CLI/server sets this; tests and library consumers omit it
   const workingDir = (options as Record<string, unknown>).workingDirectory as string | undefined;
@@ -1248,13 +1410,13 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       contextEngineResult = result;
     }).catch(() => {});
     // Periodic refresh every 60 seconds (picks up .crowclaw.md changes)
-    const contextRefresh = setInterval(() => {
+    contextRefresh = setInterval(() => {
       engine.discover().then((result) => {
         contextEngineResult = result;
       }).catch(() => {});
     }, 60_000);
     // Unref so the interval doesn't prevent process exit in tests
-    if (typeof contextRefresh === 'object' && 'unref' in contextRefresh) {
+    if (typeof contextRefresh === 'object' && contextRefresh !== null && 'unref' in contextRefresh) {
       (contextRefresh as { unref(): void }).unref();
     }
   }
@@ -1263,11 +1425,21 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
   const securityAuditLog = new SecurityAuditLog(500);
   const rateLimiter = new RateLimiter();
   const authRateLimiter = new RateLimiter();
+  // Issue #69: per-IP WS auth rate limiter with exponential backoff bans.
+  // Lives in @crowclaw/gateway so the same primitive can be reused by other
+  // runtimes (CF Workers). Defaults: 5 failures / minute trigger a 5-minute
+  // ban; bans double on each escalation up to a 1-hour cap. A successful
+  // auth resets both the failure window and the escalation level for that IP.
+  const wsAuthRateLimiter = new WsAuthRateLimiter();
   const log: Logger = createLogger({ name: 'crowclaw', level: (options as Record<string, unknown>).logLevel as 'debug' | 'info' | undefined ?? 'info' });
   const sessionMutex = new SessionMutex();
   const eventBus = new EventBus();
   let lastHeartbeatAt: string | null = null;
-  eventBus.subscribe((event) => {
+  // #118: Capture the unsubscribe so `shutdown()` can detach the listener.
+  // EventBus is per-runtime today, but listeners outliving their runtime would
+  // still pin closures (resolve fns, runtime locals) until GC, and any future
+  // refactor that hoists EventBus to a singleton would leak across runtimes.
+  const unsubscribeHeartbeatTracker = eventBus.subscribe((event) => {
     if (event.type === 'chat:complete' || event.type === 'session:updated') {
       lastHeartbeatAt = new Date().toISOString();
     }
@@ -2021,7 +2193,7 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
    * Idempotent and safe to call from a process.on('SIGTERM', ...) handler.
    * Returns a summary so the host CLI can log what was drained.
    */
-  async function shutdown(timeoutMs: number = 5_000): Promise<{ ssEClosed: number; learningAwaited: number; learningPending: number }> {
+  async function shutdown(timeoutMs: number = 5_000): Promise<{ ssEClosed: number; learningAwaited: number; learningPending: number; debouncerFlushed: number }> {
     // 1. Flush every open SSE subscriber. Close the controller, clear the
     //    heartbeat, and unsubscribe from the EventBus so we don't fire
     //    any further events into a closed stream.
@@ -2033,7 +2205,32 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
     }
     sseSubscribers.clear();
 
-    // 2. Await in-flight learning.autoCapture with a hang cap so a stuck
+    // 2. #115: Tear down the WebSocket manager — clears its 15s heartbeat
+    //    interval, unsubscribes from the EventBus, and closes every open
+    //    socket with code 1001 (server going away). Without this the
+    //    heartbeat keeps firing into a runtime that's been replaced and
+    //    every back-to-back `createNodeRuntime()` accumulates intervals.
+    try { wsManager.stop(); } catch { /* best-effort */ }
+
+    // 3. #118: Detach the heartbeat-tracker EventBus listener so its
+    //    closure (which captures `lastHeartbeatAt`) doesn't pin the
+    //    runtime's locals after shutdown.
+    try { unsubscribeHeartbeatTracker(); } catch { /* best-effort */ }
+
+    // 4. #119: Stop the context-engine refresh interval. Two consecutive
+    //    `createNodeRuntime({ workingDirectory })` calls would otherwise
+    //    leave a 60s interval ticking against the previous engine.
+    if (contextRefresh) {
+      clearInterval(contextRefresh);
+      contextRefresh = null;
+    }
+
+    // 5. #120: Drain the gateway message debouncer. Each pending entry
+    //    holds a setTimeout handle plus a resolve closure; without an
+    //    explicit flush they survive past shutdown until the timer fires.
+    const debouncerFlushed = gatewayDebouncer.flush();
+
+    // 6. Await in-flight learning.autoCapture with a hang cap so a stuck
     //    extractor can't block shutdown indefinitely. Promises are wrapped
     //    in trackLearning() which swallows errors, so allSettled is safe.
     const pending = [...inFlightLearning];
@@ -2053,6 +2250,7 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       ssEClosed,
       learningAwaited,
       learningPending: inFlightLearning.size,
+      debouncerFlushed,
     };
   }
 
@@ -2124,6 +2322,27 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
         }
       }
 
+      // #128: Body-size cap for state-changing methods. A declared
+      // Content-Length above 1 MiB is rejected before we ever touch the
+      // body stream — this is the cheap layer that stops a 1 GB JSON DoS
+      // from buffering through `request.json()` on the unauthenticated
+      // `/api/auth/verify` route or any other POST surface. Routes that
+      // need defense against missing/lying Content-Length (chunked
+      // transfers) additionally read with `readJsonWithSizeCap`.
+      if (request.method === 'POST' || request.method === 'PUT' || request.method === 'PATCH' || request.method === 'DELETE') {
+        const cap = checkContentLengthCap(request);
+        if (cap) {
+          log.warn('Request body exceeds size cap', {
+            component: 'security',
+            path: url.pathname,
+            method: request.method,
+            contentLength: request.headers.get('content-length'),
+            clientIp: getClientIp(request),
+          });
+          return cap;
+        }
+      }
+
       // Stricter rate limit for credential-checking endpoints only.
       // /api/auth/check is a passive cookie/bearer status read that the dashboard
       // hits on every page load — counting it as an "auth attempt" exhausts the
@@ -2161,7 +2380,13 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
           }
           return Response.json({ error: 'CROWCLAW_DASHBOARD_TOKEN is required when binding to non-localhost' }, { status: 500 });
         }
-        const body = (await request.json()) as { token?: string };
+        // #128: defensive read — caps the body even when Content-Length is
+        // absent or lying (chunked transfers). This is the unauthenticated
+        // surface, so it is the highest-value site to harden beyond the
+        // header precheck above.
+        const parsed = await readJsonWithSizeCap<{ token?: string }>(request);
+        if (!parsed.ok) return parsed.response;
+        const body = parsed.value;
         if (dashToken && timingSafeEqual(body.token ?? '', dashToken)) {
           const cookieValue = getDerivedCookieToken(dashToken);
           const secureSuffix = isLocalhost ? '' : '; Secure';
@@ -2425,8 +2650,12 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
         //      reflect what the runtime would actually serve, not entries
         //      that have been idle for >1h with no chance of resumption.
         pruneStaleBridgeSessions(codeBridgeSessions);
+        // #116: Prune the BridgeProcessRecord Map alongside the session Map.
+        // Without this, entries marked dead but never explicitly terminated
+        // (e.g. child exited but `terminateBridgeProcess` was never called)
+        // accumulate forever and the dashboard counts grow unbounded.
+        pruneDeadBridgeProcesses(bridgeProcesses);
         pruneStaleBrowserSessions(browserSessions);
-        const dynamicMcpClient = mcpClient as unknown as { getStatus?: () => unknown };
         const bridgeProcessSummary = [...bridgeProcesses.values()].map((process) => ({
           sessionId: process.sessionId,
           protocolVersion: process.protocolVersion,
@@ -2481,9 +2710,9 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
             // badge on the Overview panel. `getStatus()` exposes cache-level
             // state only; attach the server list from `getServerStatus()` so
             // the UI count tracks reality.
-            const status = dynamicMcpClient.getStatus ? dynamicMcpClient.getStatus() : null;
+            const status = mcpClient.getStatus();
             if (!status) return null;
-            const serverStatus = (dynamicMcpClient as unknown as { getServerStatus?: () => Record<string, unknown> }).getServerStatus?.() ?? {};
+            const serverStatus = (mcpClient as unknown as { getServerStatus?: () => Record<string, unknown> }).getServerStatus?.() ?? {};
             return { ...status, servers: Object.keys(serverStatus) };
           })(),
           gateway: {
@@ -2515,8 +2744,7 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
           ? String((options.provider as unknown as Record<string, unknown>).model)
           : 'unknown';
         const isEcho = providerName.toLowerCase().includes('echo') || !options.provider;
-        const dynamicMcpCap = mcpClient as unknown as { getStatus?: () => unknown };
-        const mcpStatus = dynamicMcpCap.getStatus ? dynamicMcpCap.getStatus() : null;
+        const mcpStatus = mcpClient.getStatus();
         const hasMcp = Boolean(mcpStatus);
         const hasGateway = Boolean(options.slackSigningSecret);
         const toolCount = tools.list().length;
@@ -2547,8 +2775,7 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       }
 
       if (request.method === 'GET' && url.pathname === '/api/system/preflight') {
-        const dynamicMcpClient = mcpClient as unknown as { getStatus?: () => { degraded?: boolean } | null };
-        const mcpStatus = dynamicMcpClient.getStatus ? dynamicMcpClient.getStatus() : null;
+        const mcpStatus = mcpClient.getStatus();
         return Response.json({
           ok: true,
           deployment: deploymentName,
@@ -2571,11 +2798,12 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
         // #35: prune-on-read here too — release-check is a heavy enumeration
         //      that's a natural place to flush stale entries.
         pruneStaleBridgeSessions(codeBridgeSessions);
+        // #116: Prune the BridgeProcessRecord Map alongside the session Map.
+        // Without this, entries marked dead but never explicitly terminated
+        // (e.g. child exited but `terminateBridgeProcess` was never called)
+        // accumulate forever and the dashboard counts grow unbounded.
+        pruneDeadBridgeProcesses(bridgeProcesses);
         pruneStaleBrowserSessions(browserSessions);
-        const dynamicMcpClient = mcpClient as unknown as {
-          getStatus?: () => unknown;
-          inspect?: (options?: { refresh?: boolean }) => Promise<unknown>;
-        };
         const bridgeProcessSummary = [...bridgeProcesses.values()].map((process) => ({
           sessionId: process.sessionId,
           pid: process.pid,
@@ -2607,20 +2835,11 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
         }));
         const defaultBridgeSession = codeBridgeSessions.get('cli-default');
         const defaultBridgeProcess = bridgeProcesses.get('cli-default');
-        const dynamicMcpStatus = dynamicMcpClient.getStatus ? dynamicMcpClient.getStatus() : null;
+        const dynamicMcpStatus = mcpClient.getStatus();
         let inspectedMcp: unknown;
-        if (dynamicMcpClient.inspect) {
-          try {
-            inspectedMcp = await dynamicMcpClient.inspect();
-          } catch {
-            inspectedMcp = {
-              status: dynamicMcpStatus,
-              tools: [],
-              resources: [],
-              prompts: []
-            };
-          }
-        } else {
+        try {
+          inspectedMcp = await mcpClient.inspect();
+        } catch {
           inspectedMcp = {
             status: dynamicMcpStatus,
             tools: [],
@@ -4543,13 +4762,11 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       }
 
       if (request.method === 'GET' && url.pathname === '/api/mcp/resources') {
-        const dynamicClient = mcpClient as unknown as { listResources?: () => Promise<unknown[]> };
-        return Response.json(dynamicClient.listResources ? await dynamicClient.listResources() : []);
+        return Response.json(await mcpClient.listResources());
       }
 
       if (request.method === 'GET' && url.pathname === '/api/mcp/prompts') {
-        const dynamicClient = mcpClient as unknown as { listPrompts?: () => Promise<unknown[]> };
-        return Response.json(dynamicClient.listPrompts ? await dynamicClient.listPrompts() : []);
+        return Response.json(await mcpClient.listPrompts());
       }
 
       if (request.method === 'GET' && url.pathname === routePaths.mcp.serverTools) {
@@ -4634,8 +4851,7 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       }
 
       if (request.method === 'GET' && url.pathname === '/api/mcp/status') {
-        const dynamicClient = mcpClient as unknown as { getStatus?: () => unknown };
-        return Response.json(dynamicClient.getStatus ? dynamicClient.getStatus() : null);
+        return Response.json(mcpClient.getStatus());
       }
 
       if (request.method === 'GET' && url.pathname === '/api/mcp/inspect') {
@@ -4675,11 +4891,7 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
       }
 
       if (request.method === 'POST' && url.pathname === '/api/mcp/verify') {
-        const dynamicClient = mcpClient as unknown as { verify?: (options?: { timeoutMs?: number }) => Promise<unknown> };
-        if (dynamicClient.verify) {
-          return Response.json(await dynamicClient.verify());
-        }
-        return Response.json({ ok: false, error: 'verify not supported on this client', latencyMs: 0 });
+        return Response.json(await mcpClient.verify());
       }
 
       if (request.method === 'GET' && url.pathname === '/api/mcp/presets/status') {
@@ -5883,6 +6095,27 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
 
       // --- WebSocket upgrade (auth via HttpOnly cookie or Authorization header) ---
       if (request.method === 'GET' && url.pathname === '/ws') {
+        // Issue #69: rate-limit WS auth attempts before reading credentials.
+        // OpenClaw CVE-2026-32025 — without this, an attacker can brute-force
+        // the dashboard token at HTTP-handshake speed (the prior `/ws` path
+        // had no per-IP cap; only REST routes did). The limiter denies during
+        // the active ban window and emits Retry-After so well-behaved clients
+        // back off. Successful auth clears the ban-escalation level for the IP.
+        const wsClientIp = getClientIp(request);
+        const wsDecision = wsAuthRateLimiter.beforeAuth(wsClientIp);
+        if (!wsDecision.allowed) {
+          log.warn('WS auth rate limit triggered', {
+            component: 'security',
+            clientIp: wsClientIp,
+            reason: wsDecision.reason,
+            retryAfterSec: wsDecision.retryAfterSec,
+          });
+          return new Response('Too many WebSocket auth attempts', {
+            status: 429,
+            headers: { 'Retry-After': String(wsDecision.retryAfterSec ?? 300) },
+          });
+        }
+
         // Prefer the cookie the browser already holds from /api/auth/verify.
         // Bearer header stays supported for non-browser clients. We intentionally
         // do NOT accept `?token=...` query params: they leak into access logs,
@@ -5897,8 +6130,14 @@ export function createNodeRuntime(options: NodeRuntimeOptions = {}) {
         const wsAuthenticated = cookieMatches || bearerMatches;
 
         if (dashToken && !wsAuthenticated) {
+          // Issue #69: count this as a failed auth attempt so repeated bad
+          // tokens trigger the exponential backoff ban.
+          wsAuthRateLimiter.recordFailure(wsClientIp);
           return new Response('Unauthorized — authenticated cookie or Authorization header required', { status: 401 });
         }
+        // Issue #69: clear the failure window + ban escalation for this IP
+        // so a legitimate user does not stay penalised after fixing their token.
+        wsAuthRateLimiter.recordSuccess(wsClientIp);
         // Only the owner-of-the-host (localhost + no token configured) gets
         // "authenticated" privileges (can send session:abort). Without this
         // tightening, any local process or malicious page could abort sessions

--- a/packages/sandbox-executor/package.json
+++ b/packages/sandbox-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/sandbox-executor",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.8.9",
-    "@crowclaw/core": "0.6.0",
-    "@crowclaw/tools": "0.6.0"
+    "@crowclaw/core": "0.6.1",
+    "@crowclaw/tools": "0.6.1"
   }
 }

--- a/packages/sandbox-executor/package.json
+++ b/packages/sandbox-executor/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/scheduler",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/storage",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,8 +17,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.0",
-    "@crowclaw/shared": "0.6.0"
+    "@crowclaw/core": "0.6.1",
+    "@crowclaw/shared": "0.6.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/tools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,12 +17,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.0",
-    "@crowclaw/gateway": "0.6.0",
-    "@crowclaw/memory": "0.6.0",
-    "@crowclaw/mcp": "0.6.0",
-    "@crowclaw/scheduler": "0.6.0",
-    "@crowclaw/storage": "0.6.0",
-    "@crowclaw/workspace": "0.6.0"
+    "@crowclaw/core": "0.6.1",
+    "@crowclaw/gateway": "0.6.1",
+    "@crowclaw/memory": "0.6.1",
+    "@crowclaw/mcp": "0.6.1",
+    "@crowclaw/scheduler": "0.6.1",
+    "@crowclaw/storage": "0.6.1",
+    "@crowclaw/workspace": "0.6.1"
   }
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -383,9 +383,81 @@ function hasApprovalGate(input: Record<string, unknown>, context: ToolExecutionC
   if (input.__approvalGranted === true) return true;
   const env = context.env as Record<string, unknown> | undefined;
   if (env && env.crowclawApprovalGranted === true) return true;
-  const approval = (context as unknown as { approval?: unknown }).approval;
-  if (typeof approval === 'function') return true;
+  if (typeof getApprovalCallback(context) === 'function') return true;
   return false;
+}
+
+/**
+ * Public approval callback shape. Hosts attach one of these to a
+ * `ToolExecutionContext` (via `withApproval`) so any tool — including those
+ * dispatched concurrently through `Promise.all` (issue #86) — can ask for
+ * an explicit operator decision.
+ */
+export type ApprovalCallback = (request: {
+  toolName: string;
+  input: Record<string, unknown>;
+  sessionId: string;
+}) => Promise<boolean>;
+
+/**
+ * Issue #86 — when AgentLoop runs a parallel-safety partition through
+ * `Promise.all`, every concurrent worker reads from the *same* context
+ * object. Tools can no longer assume a fresh per-call context, so the
+ * approval reference must live somewhere stable. We snapshot it onto a
+ * dedicated symbol slot in `ToolRegistry.execute` and read it back here, so
+ * a host that mutates `context.approval` mid-flight cannot accidentally
+ * disable the gate for an in-flight worker.
+ */
+const APPROVAL_SLOT = Symbol.for('crowclaw.tools.approval');
+
+type ContextWithApproval = ToolExecutionContext & {
+  approval?: ApprovalCallback;
+  [APPROVAL_SLOT]?: ApprovalCallback;
+};
+
+function getApprovalCallback(
+  context: ToolExecutionContext,
+): ApprovalCallback | undefined {
+  const ctx = context as ContextWithApproval;
+  // Frozen snapshot wins — set by ToolRegistry.execute on every dispatch so
+  // concurrent Promise.all workers see a stable callback even if a later
+  // hook re-assigns `context.approval`.
+  const snapshot = ctx[APPROVAL_SLOT];
+  if (typeof snapshot === 'function') return snapshot;
+  if (typeof ctx.approval === 'function') return ctx.approval;
+  return undefined;
+}
+
+/**
+ * Attach an approval callback to a `ToolExecutionContext` for downstream
+ * tools. Returns a *new* context object so callers cannot accidentally
+ * mutate a shared parent context. AgentLoop should use this when fanning
+ * tool calls out across `Promise.all` workers (#86).
+ */
+export function withApproval(
+  context: ToolExecutionContext,
+  approval: ApprovalCallback,
+): ToolExecutionContext {
+  return { ...context, approval } as ToolExecutionContext;
+}
+
+/**
+ * Invoke the approval callback registered on the context, if any. Returns
+ * `false` when no callback is present, or when the callback rejects/throws —
+ * tools must fail closed on approval errors (#86).
+ */
+export async function requestApproval(
+  context: ToolExecutionContext,
+  toolName: string,
+  input: Record<string, unknown>,
+): Promise<boolean> {
+  const callback = getApprovalCallback(context);
+  if (!callback) return false;
+  try {
+    return await callback({ toolName, input, sessionId: context.sessionId });
+  } catch {
+    return false;
+  }
 }
 
 function normalizeScope(input: Record<string, unknown>): 'session' | 'user' | 'workspace' | undefined {
@@ -444,12 +516,30 @@ export class ToolRegistry implements ToolCatalog, ToolExecutor {
       };
     }
 
+    // Issue #86 — snapshot the host-supplied approval callback into a
+    // per-dispatch symbol slot so concurrent `Promise.all` tool workers
+    // see a stable reference. AgentLoop's safety-partition fan-out reuses
+    // a single context object across N parallel `executeToolCall` calls;
+    // without this snapshot, a later assignment to `context.approval`
+    // (e.g. a teardown hook) could disable the gate for an in-flight
+    // worker. We also clone the context so a tool that mutates
+    // `context.env` mid-call can't poison sibling workers.
+    const sourceCtx = context as ContextWithApproval;
+    const approvalSnapshot = sourceCtx.approval ?? sourceCtx[APPROVAL_SLOT];
+    const dispatchCtx = { ...context } as ContextWithApproval;
+    if (typeof approvalSnapshot === 'function') {
+      dispatchCtx[APPROVAL_SLOT] = approvalSnapshot;
+      // Preserve the public `.approval` property so older tools that read
+      // `context.approval` directly still see the callback.
+      dispatchCtx.approval = approvalSnapshot;
+    }
+
     // Wall-clock duration for observability (#58). Includes network/IO end-to-end.
     // Surfaced via `result.metadata.duration_ms` so existing `tool:result` consumers
     // (LearningPipeline, dashboard latency tracking) can read it without changes
     // to the cross-package PluginHookPayloads contract.
     const start = performance.now();
-    const result = await tool.execute(input, context);
+    const result = await tool.execute(input, dispatchCtx);
     const duration_ms = Math.round(performance.now() - start);
     return {
       ...result,
@@ -1395,6 +1485,50 @@ export function createLinePatchTool(): ToolDefinition {
   };
 }
 
+/**
+ * Issue #88 — Dedup-stub repetition tracker for `workspace.read`. Some
+ * agents stall by re-issuing the same read tool call back-to-back (the
+ * "read this file again to be sure" loop), wasting iterations and tokens.
+ * Once the same `(sessionId, path)` pair is read more than
+ * `WORKSPACE_READ_DEDUP_LIMIT` times, the tool short-circuits with a
+ * synthetic BLOCKED result. The agent loop surfaces the `tool:blocked_dedup`
+ * metadata flag so downstream observers (dashboard, learning pipeline) can
+ * count escalations without parsing the output string.
+ *
+ * Tracker scope: per-session, per-path. Keyed by `${sessionId}::${path}`.
+ * Reset by `resetWorkspaceReadDedup()` (test/host hook).
+ */
+export const WORKSPACE_READ_DEDUP_LIMIT = 3;
+const workspaceReadCounts = new Map<string, number>();
+
+function workspaceReadDedupKey(sessionId: string | undefined, path: string): string {
+  return `${sessionId ?? '__unknown__'}::${path}`;
+}
+
+/**
+ * Reset the per-session workspace-read dedup tracker. Hosts should call
+ * this on session end so a long-lived process doesn't leak state across
+ * unrelated sessions. Tests call it for isolation.
+ */
+export function resetWorkspaceReadDedup(sessionId?: string): void {
+  if (sessionId === undefined) {
+    workspaceReadCounts.clear();
+    return;
+  }
+  const prefix = `${sessionId}::`;
+  for (const key of [...workspaceReadCounts.keys()]) {
+    if (key.startsWith(prefix)) workspaceReadCounts.delete(key);
+  }
+}
+
+/** Inspect the current dedup count for `(sessionId, path)`. Test helper. */
+export function getWorkspaceReadDedupCount(
+  sessionId: string,
+  path: string,
+): number {
+  return workspaceReadCounts.get(workspaceReadDedupKey(sessionId, path)) ?? 0;
+}
+
 export function createWorkspaceReadTool(workspace: WorkspaceStore): ToolDefinition {
   return {
     manifest: {
@@ -1408,15 +1542,53 @@ export function createWorkspaceReadTool(workspace: WorkspaceStore): ToolDefiniti
       dangerLevel: 'low',
       inputSchema: { type: 'object', properties: { path: { type: 'string', description: 'File path to read' } }, required: ['path'] }
     },
-    async execute(input) {
+    async execute(input, context) {
       const path = typeof input.path === 'string' ? input.path : '';
+      if (!path) {
+        return {
+          toolName: 'workspace.read',
+          runtime: 'worker',
+          ok: false,
+          output: 'Missing path.',
+          metadata: { path }
+        };
+      }
+
+      // #88 — Dedup escalation. Bump *before* the read so a runaway loop is
+      // blocked on the third re-issue, not the fourth. The first
+      // WORKSPACE_READ_DEDUP_LIMIT attempts pass through unchanged.
+      const dedupKey = workspaceReadDedupKey(context.sessionId, path);
+      const previous = workspaceReadCounts.get(dedupKey) ?? 0;
+      const next = previous + 1;
+      workspaceReadCounts.set(dedupKey, next);
+      if (next > WORKSPACE_READ_DEDUP_LIMIT) {
+        return {
+          toolName: 'workspace.read',
+          runtime: 'worker',
+          ok: false,
+          output:
+            `BLOCKED: workspace.read("${path}") has already been called ${previous} times this session. ` +
+            `If the file content has not changed, use the prior result; otherwise call workspace.list / workspace.searchFiles to check the path.`,
+          metadata: {
+            path,
+            reads: next,
+            limit: WORKSPACE_READ_DEDUP_LIMIT,
+            blocked: true,
+            'tool:blocked_dedup': true,
+            sessionId: context.sessionId,
+          },
+        };
+      }
+
       const file = await workspace.read(path);
       return {
         toolName: 'workspace.read',
         runtime: 'worker',
         ok: Boolean(file),
         output: file?.content ?? 'Workspace file not found.',
-        metadata: file ? { path: file.path, updatedAt: file.updatedAt } : { path }
+        metadata: file
+          ? { path: file.path, updatedAt: file.updatedAt, reads: next }
+          : { path, reads: next }
       };
     }
   };

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "dev": "vite --config ui/vite.config.mjs",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/workspace",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -11,8 +11,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "devDependencies": {
     "@types/node": "^24.9.1"

--- a/scripts/link-workspaces.mjs
+++ b/scripts/link-workspaces.mjs
@@ -20,6 +20,12 @@ async function safeRemove(target) {
   await fs.rm(target, { recursive: true, force: true });
 }
 
+// #136: validate package name segment to refuse anything that could resolve
+// outside the scope directory or contain shell-interpretable characters.
+// `@crowclaw/<segment>` segments are owned in-repo, so they should always
+// match `[a-z0-9_-]+`; reject otherwise rather than silently symlinking.
+const PACKAGE_NAME_RE = /^[a-z0-9_-]+$/;
+
 async function main() {
   await ensureDir(nodeModulesDir);
   const scopeDir = path.join(nodeModulesDir, '@crowclaw');
@@ -27,6 +33,7 @@ async function main() {
 
   const entries = await fs.readdir(packagesDir, { withFileTypes: true });
   const linked = [];
+  const skipped = [];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const packageDir = path.join(packagesDir, entry.name);
@@ -35,6 +42,10 @@ async function main() {
       const pkg = await readJson(packageJsonPath);
       if (typeof pkg.name !== 'string' || !pkg.name.startsWith('@crowclaw/')) continue;
       const packageName = pkg.name.split('/')[1];
+      if (!packageName || !PACKAGE_NAME_RE.test(packageName)) {
+        skipped.push(pkg.name);
+        continue;
+      }
       const linkPath = path.join(scopeDir, packageName);
       await safeRemove(linkPath);
       const relativeTarget = path.relative(scopeDir, packageDir);
@@ -46,6 +57,11 @@ async function main() {
   }
 
   console.log(`Linked ${linked.length} CrowClaw workspaces.`);
+  if (skipped.length > 0) {
+    console.warn(
+      `Skipped ${skipped.length} package(s) with invalid name segment: ${skipped.join(', ')}`
+    );
+  }
 }
 
 main().catch((error) => {

--- a/tests/do-idempotency-store.test.ts
+++ b/tests/do-idempotency-store.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Issue #159 — focused unit tests for `DurableObjectIdempotencyStore`.
+ *
+ * The leak-fix sweep in `v06-leak-fixes.test.ts` already pins #117 (maxEntries
+ * cap) and #153 (concurrent hydrate serialization). This file is the dedicated
+ * unit suite called out in #159 and exercises four orthogonal contracts of the
+ * store so future regressions surface here directly:
+ *
+ *   (a) Concurrent `markIfAbsent` calls for the SAME key resolve to exactly one
+ *       `true` and the rest `false` — the store must not race-double-mark.
+ *   (b) TTL expiry + eviction — keys past `expiresAt` are dropped on the next
+ *       access path that runs `evict()` (`markIfAbsent` / `has`).
+ *   (c) Storage round-trip on hydrate — entries persisted to DO storage are
+ *       restored after a fresh instance is constructed against the same backing
+ *       storage; expired entries in the snapshot are filtered on load.
+ *   (d) maxEntries cap eviction path — when the cap is exceeded, eviction
+ *       removes oldest-inserted keys first AND the persisted snapshot reflects
+ *       the post-eviction set (no stale evicted keys leak back via hydrate).
+ *
+ * The DO storage interface is mocked with an in-memory `Map` matching the
+ * `DurableObjectStateLite['storage']` subset used by the store (get/put/delete).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DurableObjectIdempotencyStore } from '../packages/runtime-cloudflare/src/agent-do.js';
+
+// ---------------------------------------------------------------------------
+// Storage mock — minimal shape matching DurableObjectStateLite['storage'].
+// Backing data lives in a plain Map so multiple stores can share it (used in
+// the hydrate round-trip test).
+// ---------------------------------------------------------------------------
+
+interface StorageMock {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  /** Direct access for assertions about persisted state. */
+  data: Map<string, unknown>;
+}
+
+function makeStorage(initial: Record<string, unknown> = {}): StorageMock {
+  const data = new Map<string, unknown>(Object.entries(initial));
+  return {
+    data,
+    get: vi.fn(async (key: string) => data.get(key)),
+    put: vi.fn(async (key: string, value: unknown) => {
+      data.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => data.delete(key)),
+  };
+}
+
+const STORAGE_KEY = 'gateway:idempotency-keys';
+
+// ---------------------------------------------------------------------------
+// (a) Concurrent markIfAbsent with the SAME key
+// ---------------------------------------------------------------------------
+
+describe('DurableObjectIdempotencyStore (#159a) — concurrent same-key markIfAbsent', () => {
+  it('returns true for exactly one caller when many race the same key', async () => {
+    const storage = makeStorage();
+    const store = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 100 });
+
+    // Fire 10 concurrent attempts on the same key without awaiting.
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => store.markIfAbsent('dup-key')),
+    );
+
+    const trues = results.filter((r) => r === true).length;
+    const falses = results.filter((r) => r === false).length;
+    expect(trues).toBe(1);
+    expect(falses).toBe(9);
+    expect(store.size).toBe(1);
+    expect(await store.has('dup-key')).toBe(true);
+  });
+
+  it('serializes hydration so storage.get is called once across racing calls', async () => {
+    // Defer storage.get so all racers stack on the same in-flight hydrate.
+    let resolveGet: ((value: Record<string, number> | undefined) => void) | null = null;
+    const storage = {
+      get: vi.fn(
+        () =>
+          new Promise<Record<string, number> | undefined>((resolve) => {
+            resolveGet = resolve;
+          }),
+      ),
+      put: vi.fn(async () => undefined),
+      delete: vi.fn(async () => true),
+    };
+    const store = new DurableObjectIdempotencyStore(storage as never, 60_000, { maxEntries: 100 });
+
+    const p1 = store.markIfAbsent('same');
+    const p2 = store.markIfAbsent('same');
+    const p3 = store.markIfAbsent('same');
+
+    // All three are blocked on a single in-flight hydrate.
+    expect(storage.get).toHaveBeenCalledTimes(1);
+
+    resolveGet!(undefined);
+    const results = await Promise.all([p1, p2, p3]);
+
+    expect(results.filter((r) => r === true).length).toBe(1);
+    expect(results.filter((r) => r === false).length).toBe(2);
+    // Hydrate is memoized — still exactly one storage.get even after resolve.
+    expect(storage.get).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) TTL expiry + eviction
+// ---------------------------------------------------------------------------
+
+describe('DurableObjectIdempotencyStore (#159b) — TTL expiry + eviction', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('drops keys whose expiresAt is in the past on the next access', async () => {
+    const storage = makeStorage();
+    const ttlMs = 1_000;
+    const store = new DurableObjectIdempotencyStore(storage, ttlMs, { maxEntries: 100 });
+
+    expect(await store.markIfAbsent('short-lived')).toBe(true);
+    expect(store.size).toBe(1);
+    expect(await store.has('short-lived')).toBe(true);
+
+    // Advance well past TTL. Next access path runs evict() → key is gone.
+    vi.advanceTimersByTime(ttlMs + 1);
+
+    expect(await store.has('short-lived')).toBe(false);
+    expect(store.size).toBe(0);
+
+    // Re-marking the same key after expiry succeeds (returns true) — the slot
+    // is treated as free.
+    expect(await store.markIfAbsent('short-lived')).toBe(true);
+    expect(store.size).toBe(1);
+  });
+
+  it('honors per-call ttlMs override for markIfAbsent', async () => {
+    const storage = makeStorage();
+    // Default TTL is 1h; per-call override sets a 100ms expiry.
+    const store = new DurableObjectIdempotencyStore(storage, 60 * 60 * 1000, { maxEntries: 100 });
+
+    expect(await store.markIfAbsent('per-call', 100)).toBe(true);
+    expect(await store.has('per-call')).toBe(true);
+
+    vi.advanceTimersByTime(101);
+    expect(await store.has('per-call')).toBe(false);
+  });
+
+  it('expires only the entries past TTL, leaving fresh ones intact', async () => {
+    const storage = makeStorage();
+    const store = new DurableObjectIdempotencyStore(storage, 1_000, { maxEntries: 100 });
+
+    await store.markIfAbsent('old');
+    vi.advanceTimersByTime(900);
+    await store.markIfAbsent('young');
+
+    // 'old' expires at +1000, 'young' at +1900. Jump to +1100.
+    vi.advanceTimersByTime(200);
+
+    expect(await store.has('old')).toBe(false);
+    expect(await store.has('young')).toBe(true);
+    expect(store.size).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) Storage round-trip on hydrate
+// ---------------------------------------------------------------------------
+
+describe('DurableObjectIdempotencyStore (#159c) — storage round-trip on hydrate', () => {
+  it('persists entries on mark and restores them in a fresh instance', async () => {
+    const storage = makeStorage();
+
+    // First store: write three keys.
+    const writer = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 100 });
+    await writer.markIfAbsent('alpha');
+    await writer.markIfAbsent('beta');
+    await writer.markIfAbsent('gamma');
+
+    // Storage should now hold the snapshot under the canonical key.
+    const persisted = storage.data.get(STORAGE_KEY) as Record<string, number> | undefined;
+    expect(persisted).toBeTruthy();
+    expect(Object.keys(persisted!).sort()).toEqual(['alpha', 'beta', 'gamma']);
+
+    // Reset the call counter so reader-only behavior is observable.
+    storage.get.mockClear();
+
+    // Second store, same backing storage — simulates a DO restart.
+    const reader = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 100 });
+
+    // Hydrate is lazy — storage.get is not called until the first await path.
+    expect(storage.get).toHaveBeenCalledTimes(0);
+
+    expect(await reader.has('alpha')).toBe(true);
+    expect(await reader.has('beta')).toBe(true);
+    expect(await reader.has('gamma')).toBe(true);
+    expect(await reader.markIfAbsent('alpha')).toBe(false);
+
+    // Reader hydrates exactly once for its lifetime, regardless of access count.
+    expect(storage.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters expired entries from the persisted snapshot at hydrate time', async () => {
+    // Pre-seed storage with a snapshot containing one fresh and one expired key.
+    const now = Date.now();
+    const storage = makeStorage({
+      [STORAGE_KEY]: {
+        fresh: now + 60_000,
+        stale: now - 1, // already expired
+      },
+    });
+
+    const store = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 100 });
+
+    expect(await store.has('fresh')).toBe(true);
+    expect(await store.has('stale')).toBe(false);
+    // Only the fresh entry survived hydration → size is 1.
+    expect(store.size).toBe(1);
+  });
+
+  it('unmark deletes from in-memory map and re-persists the snapshot', async () => {
+    const storage = makeStorage();
+    const store = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 100 });
+
+    await store.markIfAbsent('keep');
+    await store.markIfAbsent('drop');
+    storage.put.mockClear();
+
+    await store.unmark('drop');
+
+    // unmark must persist the post-deletion snapshot.
+    expect(storage.put).toHaveBeenCalledTimes(1);
+    const snapshot = storage.data.get(STORAGE_KEY) as Record<string, number>;
+    expect(Object.keys(snapshot).sort()).toEqual(['keep']);
+    expect(await store.has('drop')).toBe(false);
+    expect(await store.has('keep')).toBe(true);
+  });
+
+  it('continues with an empty map when storage.get rejects', async () => {
+    const storage = {
+      get: vi.fn(async () => {
+        throw new Error('storage broken');
+      }),
+      put: vi.fn(async () => undefined),
+      delete: vi.fn(async () => true),
+    };
+    const store = new DurableObjectIdempotencyStore(storage as never, 60_000, { maxEntries: 100 });
+
+    // Hydrate must swallow the error; markIfAbsent still works.
+    expect(await store.markIfAbsent('post-failure')).toBe(true);
+    expect(store.size).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) maxEntries cap eviction path
+// ---------------------------------------------------------------------------
+
+describe('DurableObjectIdempotencyStore (#159d) — maxEntries cap eviction', () => {
+  it('evicts the oldest-inserted key when the cap is exceeded', async () => {
+    const storage = makeStorage();
+    const store = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 3 });
+
+    await store.markIfAbsent('k1');
+    await store.markIfAbsent('k2');
+    await store.markIfAbsent('k3');
+    expect(store.size).toBe(3);
+
+    await store.markIfAbsent('k4');
+    expect(store.size).toBe(3);
+    expect(await store.has('k1')).toBe(false);
+    expect(await store.has('k2')).toBe(true);
+    expect(await store.has('k3')).toBe(true);
+    expect(await store.has('k4')).toBe(true);
+  });
+
+  it('persists the post-eviction snapshot — evicted keys do not leak via hydrate', async () => {
+    const storage = makeStorage();
+
+    // Phase 1: write past the cap so eviction runs.
+    const writer = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 2 });
+    await writer.markIfAbsent('a');
+    await writer.markIfAbsent('b');
+    await writer.markIfAbsent('c'); // evicts 'a'
+
+    // The persisted snapshot must reflect the eviction — only 'b' and 'c'.
+    const snapshot = storage.data.get(STORAGE_KEY) as Record<string, number>;
+    expect(Object.keys(snapshot).sort()).toEqual(['b', 'c']);
+    expect(snapshot).not.toHaveProperty('a');
+
+    // Phase 2: a fresh store reading the same backing storage must NOT see 'a'.
+    const reader = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 2 });
+    expect(await reader.has('a')).toBe(false);
+    expect(await reader.has('b')).toBe(true);
+    expect(await reader.has('c')).toBe(true);
+  });
+
+  it('keeps evicting as the cap stays saturated across many inserts', async () => {
+    const storage = makeStorage();
+    const store = new DurableObjectIdempotencyStore(storage, 60_000, { maxEntries: 5 });
+
+    for (let i = 0; i < 20; i++) {
+      await store.markIfAbsent(`k${i}`);
+    }
+
+    expect(store.size).toBe(5);
+    // Only the last 5 (k15..k19) should remain.
+    for (let i = 0; i < 15; i++) {
+      expect(await store.has(`k${i}`)).toBe(false);
+    }
+    for (let i = 15; i < 20; i++) {
+      expect(await store.has(`k${i}`)).toBe(true);
+    }
+  });
+});

--- a/tests/v06_1-core-plugins-layering.test.ts
+++ b/tests/v06_1-core-plugins-layering.test.ts
@@ -1,0 +1,221 @@
+/**
+ * v0.6.1 / issue #158 — verify the core ↔ plugins layering inversion is fixed.
+ *
+ * Before #158: `@crowclaw/core` declared `@crowclaw/plugins` as a runtime
+ * dependency (and imported PluginManager from it), inverting expected
+ * layering. After the fix:
+ *   - PluginManager + Plugin contract live in `@crowclaw/core`.
+ *   - `@crowclaw/plugins` is a thin re-export shim that depends on core.
+ *   - core no longer depends on plugins.
+ *
+ * These tests pin the contract: package metadata + public API surface from
+ * both entry points must keep working.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  MemoryCapturePlugin as CoreMemoryCapturePlugin,
+  PluginManager as CorePluginManager,
+} from '@crowclaw/core';
+import type {
+  Plugin as CorePlugin,
+  PluginContext as CorePluginContext,
+  PluginHookName,
+  PluginInvocationPayloads,
+  PreToolCallVeto,
+  ToolResultTransform,
+} from '@crowclaw/core';
+
+import {
+  MemoryCapturePlugin as ShimMemoryCapturePlugin,
+  PluginManager as ShimPluginManager,
+} from '@crowclaw/plugins';
+import type { Plugin as ShimPlugin } from '@crowclaw/plugins';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+async function readJson<T = unknown>(file: string): Promise<T> {
+  return JSON.parse(await fs.readFile(file, 'utf8')) as T;
+}
+
+interface PkgManifest {
+  name: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+describe('v0.6.1 #158 — core/plugins layering', () => {
+  it('core/package.json does NOT depend on @crowclaw/plugins', async () => {
+    const pkg = await readJson<PkgManifest>(
+      path.join(repoRoot, 'packages/core/package.json'),
+    );
+    expect(pkg.name).toBe('@crowclaw/core');
+    expect(pkg.dependencies?.['@crowclaw/plugins']).toBeUndefined();
+    expect(pkg.devDependencies?.['@crowclaw/plugins']).toBeUndefined();
+  });
+
+  it('plugins/package.json depends on @crowclaw/core (correct direction)', async () => {
+    const pkg = await readJson<PkgManifest>(
+      path.join(repoRoot, 'packages/plugins/package.json'),
+    );
+    expect(pkg.name).toBe('@crowclaw/plugins');
+    expect(pkg.dependencies?.['@crowclaw/core']).toBeDefined();
+  });
+
+  it('core/src/index.ts contains no import from @crowclaw/plugins', async () => {
+    const source = await fs.readFile(
+      path.join(repoRoot, 'packages/core/src/index.ts'),
+      'utf8',
+    );
+    expect(source).not.toMatch(/from '@crowclaw\/plugins'/);
+  });
+
+  it('core/src/plugins.ts is the canonical home for PluginManager', async () => {
+    const source = await fs.readFile(
+      path.join(repoRoot, 'packages/core/src/plugins.ts'),
+      'utf8',
+    );
+    expect(source).toMatch(/export class PluginManager/);
+    expect(source).toMatch(/export interface Plugin\b/);
+    expect(source).toMatch(/export class MemoryCapturePlugin/);
+  });
+
+  it('plugins/src/index.ts is a re-export shim from @crowclaw/core', async () => {
+    const source = await fs.readFile(
+      path.join(repoRoot, 'packages/plugins/src/index.ts'),
+      'utf8',
+    );
+    expect(source).toMatch(/from '@crowclaw\/core'/);
+    // Shim must NOT redeclare the implementation.
+    expect(source).not.toMatch(/class PluginManager/);
+    expect(source).not.toMatch(/class MemoryCapturePlugin/);
+  });
+});
+
+describe('v0.6.1 #158 — public contract still works', () => {
+  it('PluginManager from @crowclaw/core and @crowclaw/plugins are the same class', () => {
+    expect(CorePluginManager).toBe(ShimPluginManager);
+    expect(CoreMemoryCapturePlugin).toBe(ShimMemoryCapturePlugin);
+  });
+
+  it('register + list + emit observer hooks fire in order', async () => {
+    const manager = new CorePluginManager();
+    const observer = new CoreMemoryCapturePlugin();
+    manager.register(observer);
+
+    expect(manager.list()).toHaveLength(1);
+    expect(manager.list()[0]).toBe(observer);
+
+    const ctx: CorePluginContext = {
+      runtime: 'test',
+      sessionId: 'sess-1',
+      agentId: 'agent-1',
+    };
+    await manager.emit(
+      'agent:beforeRun',
+      { input: { agentId: 'agent-1', sessionId: 'sess-1' } },
+      ctx,
+    );
+    await manager.emit(
+      'tool:beforeExecute',
+      { toolName: 'echo', input: {}, sessionId: 'sess-1', agentId: 'agent-1' },
+      ctx,
+    );
+    expect(observer.seen.map((s) => s.hook)).toEqual<PluginHookName[]>([
+      'agent:beforeRun',
+      'tool:beforeExecute',
+    ]);
+  });
+
+  it('preToolCall OR-aggregates: any veto blocks; first wins', async () => {
+    const manager = new CorePluginManager();
+    const allowPlugin: CorePlugin = {
+      name: 'allow',
+      preToolCall: (): PreToolCallVeto => ({ veto: false }),
+    };
+    const denyPlugin: CorePlugin = {
+      name: 'deny',
+      preToolCall: (): PreToolCallVeto => ({ veto: true, reason: 'nope' }),
+    };
+    manager.register(allowPlugin);
+    manager.register(denyPlugin);
+
+    const ctx: CorePluginContext = {
+      runtime: 'test',
+      sessionId: 's',
+      agentId: 'a',
+    };
+    const verdict = await manager.preToolCall(
+      { toolName: 'web.fetch', input: {}, sessionId: 's', agentId: 'a' },
+      ctx,
+    );
+    expect(verdict.veto).toBe(true);
+    expect(verdict.reason).toMatch(/^deny: nope$/);
+  });
+
+  it('preToolCall: throwing plugin does not block the tool', async () => {
+    const manager = new CorePluginManager();
+    const throwingPlugin: CorePlugin = {
+      name: 'broken',
+      preToolCall: () => {
+        throw new Error('plugin crashed');
+      },
+    };
+    manager.register(throwingPlugin);
+
+    const verdict = await manager.preToolCall(
+      { toolName: 'echo', input: {}, sessionId: 's', agentId: 'a' },
+      { runtime: 'test', sessionId: 's', agentId: 'a' },
+    );
+    expect(verdict.veto).toBe(false);
+  });
+
+  it('transformToolResult chains overrides in registration order', async () => {
+    const manager = new CorePluginManager();
+    const upper: CorePlugin = {
+      name: 'upper',
+      transformToolResult: ({ result }): ToolResultTransform => ({
+        output: result.output.toUpperCase(),
+      }),
+    };
+    const tagger: CorePlugin = {
+      name: 'tagger',
+      transformToolResult: (): ToolResultTransform => ({
+        metadata: { tagged: true },
+      }),
+    };
+    manager.register(upper);
+    manager.register(tagger);
+
+    const payload: PluginInvocationPayloads['tool:transformResult']['payload'] = {
+      toolName: 'echo',
+      input: {},
+      result: { toolName: 'echo', ok: true, output: 'hello', metadata: { src: 'core' } },
+      sessionId: 's',
+      agentId: 'a',
+    };
+    const final = await manager.transformToolResult(payload, {
+      runtime: 'test',
+      sessionId: 's',
+      agentId: 'a',
+    });
+    expect(final.output).toBe('HELLO');
+    expect(final.ok).toBe(true);
+    expect(final.metadata).toEqual({ src: 'core', tagged: true });
+  });
+
+  it('shim Plugin type is structurally compatible with core Plugin type', () => {
+    // Compile-time assertion: a shim Plugin can be assigned to a core Plugin slot
+    // and vice-versa. If the shim diverged, this would fail typecheck.
+    const fromShim: ShimPlugin = { name: 'x' };
+    const fromCore: CorePlugin = fromShim;
+    const back: ShimPlugin = fromCore;
+    expect(back.name).toBe('x');
+  });
+});

--- a/tests/v06_1-gateway.test.ts
+++ b/tests/v06_1-gateway.test.ts
@@ -1,0 +1,288 @@
+/**
+ * v0.6.1 gateway sweep regression tests.
+ *
+ *   #69   WS auth rate limiting with exponential backoff (CVE-2026-32025 parity)
+ *   #78   poison replay-unsafe inbound dedupe after first visible progress
+ *   #109  concurrent Telegram update handling with p-limit
+ *   #134  scrub bot tokens from error messages and URLs in status
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryGatewayIdempotencyStore,
+  WsAuthRateLimiter,
+  scrubBotToken,
+  GatewayRunner,
+} from '@crowclaw/gateway';
+
+// -----------------------------------------------------------------------------
+// #134 — bot token scrubbing
+// -----------------------------------------------------------------------------
+
+describe('#134 scrubBotToken', () => {
+  it('redacts a single Telegram bot token', () => {
+    const input = 'fetch failed: GET https://api.telegram.org/bot1234567890:AAH-AbCDef_GhIjKlMnOpQrStUvWxYz/getMe';
+    expect(scrubBotToken(input)).toBe(
+      'fetch failed: GET https://api.telegram.org/bot[REDACTED]/getMe',
+    );
+  });
+
+  it('redacts multiple tokens in the same string', () => {
+    const input = 'tried bot111:AAA_aaa-bbb then bot222:BBB-ccc_ddd';
+    expect(scrubBotToken(input)).toBe('tried bot[REDACTED] then bot[REDACTED]');
+  });
+
+  it('leaves token-free strings untouched', () => {
+    expect(scrubBotToken('Network unreachable')).toBe('Network unreachable');
+    expect(scrubBotToken('')).toBe('');
+  });
+
+  it('does not redact innocuous "bot" prefixes', () => {
+    // Looks similar but lacks the digits-then-colon shape — must not match.
+    expect(scrubBotToken('robot:hello')).toBe('robot:hello');
+    expect(scrubBotToken('bot:no_digits')).toBe('bot:no_digits');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// #69 — WS auth rate limiter with exponential backoff
+// -----------------------------------------------------------------------------
+
+describe('#69 WsAuthRateLimiter', () => {
+  it('allows the first burst of attempts up to the threshold', () => {
+    const limiter = new WsAuthRateLimiter({ maxAttempts: 5, baseBanMs: 60_000 });
+    for (let i = 0; i < 4; i += 1) {
+      expect(limiter.beforeAuth('1.2.3.4').allowed).toBe(true);
+      limiter.recordFailure('1.2.3.4');
+    }
+    // 5th attempt is still allowed to reach the auth handler — the failure
+    // we record below is what crosses the threshold.
+    expect(limiter.beforeAuth('1.2.3.4').allowed).toBe(true);
+    limiter.recordFailure('1.2.3.4');
+  });
+
+  it('bans the IP after maxAttempts failures inside the window', () => {
+    const limiter = new WsAuthRateLimiter({ maxAttempts: 5, baseBanMs: 60_000 });
+    for (let i = 0; i < 5; i += 1) {
+      limiter.beforeAuth('9.9.9.9');
+      limiter.recordFailure('9.9.9.9');
+    }
+    const decision = limiter.beforeAuth('9.9.9.9');
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('banned');
+    expect(decision.retryAfterSec).toBeGreaterThan(0);
+    expect(decision.retryAfterSec).toBeLessThanOrEqual(60);
+  });
+
+  it('does not affect other IPs', () => {
+    const limiter = new WsAuthRateLimiter({ maxAttempts: 3 });
+    for (let i = 0; i < 3; i += 1) {
+      limiter.beforeAuth('5.5.5.5');
+      limiter.recordFailure('5.5.5.5');
+    }
+    expect(limiter.beforeAuth('5.5.5.5').allowed).toBe(false);
+    expect(limiter.beforeAuth('6.6.6.6').allowed).toBe(true);
+  });
+
+  it('escalates ban duration exponentially across consecutive bans', () => {
+    // Use a tiny baseBanMs so the test does not need to fast-forward time —
+    // we rely on `getBan(...).level` to verify the escalation arithmetic.
+    const limiter = new WsAuthRateLimiter({
+      maxAttempts: 2,
+      baseBanMs: 1_000,
+      maxBanMs: 120_000,
+    });
+    // First ban — level 1.
+    for (let i = 0; i < 2; i += 1) {
+      limiter.beforeAuth('7.7.7.7');
+      limiter.recordFailure('7.7.7.7');
+    }
+    const ban1 = limiter.getBan('7.7.7.7');
+    expect(ban1?.level).toBe(1);
+
+    // Force the entry's `until` into the past so the next `beforeAuth` walks
+    // the "ban expired but level survives" branch.
+    if (ban1) ban1.until = Date.now() - 1;
+
+    // Trigger another burst — level should escalate to 2.
+    for (let i = 0; i < 2; i += 1) {
+      limiter.beforeAuth('7.7.7.7');
+      limiter.recordFailure('7.7.7.7');
+    }
+    const ban2 = limiter.getBan('7.7.7.7');
+    expect(ban2?.level).toBe(2);
+  });
+
+  it('honours 100 rapid bad-token attempts from one IP without all reaching auth', () => {
+    // Mirror the issue's acceptance criterion verbatim.
+    const limiter = new WsAuthRateLimiter({ maxAttempts: 5 });
+    let allowed = 0;
+    let denied = 0;
+    for (let i = 0; i < 100; i += 1) {
+      const decision = limiter.beforeAuth('attacker');
+      if (decision.allowed) {
+        allowed += 1;
+        limiter.recordFailure('attacker');
+      } else {
+        denied += 1;
+      }
+    }
+    // At most maxAttempts (5) requests should ever reach the auth handler.
+    expect(allowed).toBeLessThanOrEqual(5);
+    expect(denied).toBeGreaterThanOrEqual(95);
+  });
+
+  it('clears the ban level on successful auth', () => {
+    const limiter = new WsAuthRateLimiter({ maxAttempts: 3 });
+    for (let i = 0; i < 3; i += 1) {
+      limiter.beforeAuth('legit');
+      limiter.recordFailure('legit');
+    }
+    expect(limiter.getBan('legit')?.level).toBeGreaterThanOrEqual(1);
+    limiter.recordSuccess('legit');
+    expect(limiter.getBan('legit')).toBeNull();
+    // Subsequent attempts start fresh.
+    expect(limiter.beforeAuth('legit').allowed).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// #78 — poison-after-progress idempotency
+// -----------------------------------------------------------------------------
+
+describe('#78 InMemoryGatewayIdempotencyStore.poisonAfterProgress', () => {
+  it('claim reports fresh on first call', async () => {
+    const store = new InMemoryGatewayIdempotencyStore();
+    expect(await store.claim('k1')).toBe('fresh');
+  });
+
+  it('claim reports duplicate on second call before progress', async () => {
+    const store = new InMemoryGatewayIdempotencyStore();
+    await store.claim('k1');
+    expect(await store.claim('k1')).toBe('duplicate');
+  });
+
+  it('claim reports poisoned after poisonAfterProgress', async () => {
+    const store = new InMemoryGatewayIdempotencyStore();
+    expect(await store.claim('k1')).toBe('fresh');
+    await store.poisonAfterProgress('k1');
+    expect(await store.claim('k1')).toBe('poisoned');
+    // Idempotent — repeated retries keep returning poisoned.
+    expect(await store.claim('k1')).toBe('poisoned');
+  });
+
+  it('isPoisoned tracks the poison state independently', async () => {
+    const store = new InMemoryGatewayIdempotencyStore();
+    expect(await store.isPoisoned('k1')).toBe(false);
+    await store.claim('k1');
+    expect(await store.isPoisoned('k1')).toBe(false);
+    await store.poisonAfterProgress('k1');
+    expect(await store.isPoisoned('k1')).toBe(true);
+  });
+
+  it('markIfAbsent treats a poisoned key as occupied', async () => {
+    const store = new InMemoryGatewayIdempotencyStore();
+    await store.claim('k1');
+    await store.poisonAfterProgress('k1');
+    // Backcompat: legacy callers that only know markIfAbsent must still be
+    // told the slot is taken (false) so they do not re-run the side-effect.
+    expect(await store.markIfAbsent('k1')).toBe(false);
+  });
+
+  it('unmark does not clear the poison marker', async () => {
+    const store = new InMemoryGatewayIdempotencyStore();
+    await store.claim('k1');
+    await store.poisonAfterProgress('k1');
+    await store.unmark('k1');
+    // Replays after explicit unmark must still fail loud.
+    expect(await store.claim('k1')).toBe('poisoned');
+  });
+
+  it('matches the issue scenario: tool runs, retry must not replay', async () => {
+    // Scenario from the issue: "tool runs, halfway through provider drops
+    // connection; client retries; second call returns 409 'poisoned' instead
+    // of re-running the tool."
+    const store = new InMemoryGatewayIdempotencyStore();
+    const key = 'telegram:chat-1:update-42';
+
+    // Inbound delivery 1 — claim succeeds, tool starts running.
+    expect(await store.claim(key)).toBe('fresh');
+    // Tool emits a side-effect (e.g. sends a partial message). Runtime
+    // poisons the dedupe entry.
+    await store.poisonAfterProgress(key);
+    // Provider drops, client retries the same delivery.
+    const retryClaim = await store.claim(key);
+    expect(retryClaim).toBe('poisoned');
+    // The runtime should map this to a 409 response (asserted at the call site).
+  });
+
+  it('honours TTL — poison expires after ttlMs', async () => {
+    const store = new InMemoryGatewayIdempotencyStore();
+    await store.claim('k1', 5);
+    await store.poisonAfterProgress('k1', 5);
+    expect(await store.isPoisoned('k1')).toBe(true);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(await store.isPoisoned('k1')).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// #109 — concurrent Telegram update handling with p-limit
+// -----------------------------------------------------------------------------
+
+describe('#109 GatewayRunner concurrent update handling', () => {
+  it('updateLimiter caps concurrent in-flight tasks at 3', async () => {
+    // The runner installs a private `updateLimiter = createConcurrencyLimiter(3)`.
+    // Spinning up the real polling loop hits api.telegram.org, so instead we
+    // exercise the limiter directly with synthetic tasks. We assert the
+    // observable contract: across a batch of 10 tasks the maximum
+    // simultaneously-active count never exceeds 3.
+    const runner = new GatewayRunner({ platforms: [] });
+    const limiter = (
+      runner as unknown as { updateLimiter: <T>(fn: () => Promise<T>) => Promise<T> }
+    ).updateLimiter;
+    expect(typeof limiter).toBe('function');
+
+    let active = 0;
+    let maxActive = 0;
+    const tasks = Array.from({ length: 10 }, () =>
+      limiter(async () => {
+        active += 1;
+        if (active > maxActive) maxActive = active;
+        await new Promise((r) => setTimeout(r, 20));
+        active -= 1;
+      }),
+    );
+    await Promise.all(tasks);
+    expect(maxActive).toBe(3);
+  });
+
+  it('exposes handleTelegramUpdate so the polling loop can dispatch per-update', () => {
+    // Issue #109 requirement: per-update handling extracted into a method so
+    // the polling loop can call `Promise.all(updates.map(u => limit(() =>
+    // handleUpdate(u))))`. Verify the method exists with the expected name.
+    const runner = new GatewayRunner({ platforms: [] });
+    const handler = (
+      runner as unknown as { handleTelegramUpdate?: unknown }
+    ).handleTelegramUpdate;
+    expect(typeof handler).toBe('function');
+  });
+
+  it('a burst of 10 updates does not serialize to 10 sequential awaits', async () => {
+    // Stronger acceptance: total wall time for 10 tasks of 20ms each through
+    // a 3-wide limiter must be ~80ms (4 waves of 20ms), not ~200ms (sequential).
+    const runner = new GatewayRunner({ platforms: [] });
+    const limiter = (
+      runner as unknown as { updateLimiter: <T>(fn: () => Promise<T>) => Promise<T> }
+    ).updateLimiter;
+
+    const start = Date.now();
+    await Promise.all(
+      Array.from({ length: 10 }, () => limiter(() => new Promise((r) => setTimeout(r, 20)))),
+    );
+    const elapsed = Date.now() - start;
+    // Sequential lower bound: 200ms. With concurrency 3 we expect ~80ms;
+    // give ourselves headroom for slow CI but still much less than serial.
+    expect(elapsed).toBeLessThan(150);
+  });
+});

--- a/tests/v06_1-mcp-providers-acp.test.ts
+++ b/tests/v06_1-mcp-providers-acp.test.ts
@@ -1,0 +1,451 @@
+/**
+ * v0.6.1 — issue sweep tests for the mcp/providers/acp surfaces.
+ *
+ *   #80  McpClient sessionIdleTtlMs eviction + dispose on one-shot exit
+ *   #81  providers seedManifestCacheFromPlugin / readPluginManifestModelCatalog
+ *   #103 stdio-transport exponential-backoff reconnect
+ *   #148 AcpServer tools/list registry callback (`available` flag)
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  McpClient,
+  MultiServerMcpManager,
+  type McpTransport,
+} from '../packages/mcp/src/index.js';
+import { McpJsonRpcStdioTransport } from '../packages/mcp/src/stdio-transport.js';
+import {
+  loadManifest,
+  resetManifestCache,
+  readPluginManifestModelCatalog,
+  seedManifestCacheFromPlugin,
+  hasPluginManifestModelCatalog,
+  DEFAULT_MANIFEST_URL,
+  type ManifestCache,
+} from '../packages/providers/src/model-catalog.js';
+import { AcpServer, type AcpToolInfo } from '../packages/acp/src/index.js';
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+function makeFakeTransport(): McpTransport & { disconnect: ReturnType<typeof vi.fn> } {
+  return {
+    listTools: vi.fn(async () => [{ name: 'search', description: 'Search docs' }]),
+    callTool: vi.fn(async (name: string, args: Record<string, unknown>) => ({
+      ok: true,
+      content: { name, args },
+    })),
+    listResources: vi.fn(async () => []),
+    listPrompts: vi.fn(async () => []),
+    disconnect: vi.fn(async () => undefined),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+// =============================================================================
+// #80 — McpClient sessionIdleTtlMs + dispose
+// =============================================================================
+
+describe('#80 McpClient sessionIdleTtlMs eviction', () => {
+  it('does not evict when sessionIdleTtlMs is unset', async () => {
+    let now = 1_000_000;
+    const transport = makeFakeTransport();
+    const client = new McpClient(transport, { now: () => now });
+
+    await client.callTool('search', {});
+    now += 999_999_999;
+
+    expect(client.isIdle()).toBe(false);
+    expect(await client.sweepIfIdle()).toBe(false);
+    expect(client.isDisposed()).toBe(false);
+  });
+
+  it('reports idle once now - lastUsedAt exceeds the TTL', async () => {
+    let now = 1_000_000;
+    const transport = makeFakeTransport();
+    const client = new McpClient(transport, {
+      sessionIdleTtlMs: 60_000,
+      now: () => now,
+    });
+
+    await client.callTool('search', {});
+    now += 30_000;
+    expect(client.isIdle()).toBe(false);
+
+    now += 31_000; // total 61s idle
+    expect(client.isIdle()).toBe(true);
+    expect(client.getIdleMs()).toBe(61_000);
+  });
+
+  it('sweepIfIdle disposes idle clients and tears down the transport', async () => {
+    let now = 1_000_000;
+    const transport = makeFakeTransport();
+    const client = new McpClient(transport, {
+      sessionIdleTtlMs: 1_000,
+      now: () => now,
+    });
+
+    await client.listTools();
+    expect(client.isDisposed()).toBe(false);
+
+    now += 5_000;
+    const evicted = await client.sweepIfIdle();
+    expect(evicted).toBe(true);
+    expect(client.isDisposed()).toBe(true);
+    expect(transport.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects further calls after dispose()', async () => {
+    const transport = makeFakeTransport();
+    const client = new McpClient(transport);
+    await client.dispose();
+    await expect(client.callTool('search', {})).rejects.toThrow(/disposed/);
+    await expect(client.refreshTools()).rejects.toThrow(/disposed/);
+  });
+
+  it('dispose() is idempotent', async () => {
+    const transport = makeFakeTransport();
+    const client = new McpClient(transport);
+    await client.dispose();
+    await client.dispose();
+    expect(transport.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('touch is updated on every successful op', async () => {
+    let now = 1_000;
+    const transport = makeFakeTransport();
+    const client = new McpClient(transport, { now: () => now });
+
+    const t0 = client.getLastUsedAt();
+    now = 5_000;
+    await client.callTool('search', {});
+    expect(client.getLastUsedAt()).toBe(5_000);
+    expect(client.getLastUsedAt()).toBeGreaterThan(t0);
+
+    now = 9_000;
+    await client.listResources();
+    expect(client.getLastUsedAt()).toBe(9_000);
+  });
+
+  it('MultiServerMcpManager.sweepIdle evicts only idle servers', async () => {
+    let now = 1_000_000;
+    const hot = makeFakeTransport();
+    const cold = makeFakeTransport();
+    const hotClient = new McpClient(hot, { sessionIdleTtlMs: 60_000, now: () => now });
+    const coldClient = new McpClient(cold, { sessionIdleTtlMs: 60_000, now: () => now });
+
+    await hotClient.callTool('search', {});
+    await coldClient.callTool('search', {});
+
+    now += 30_000;
+    await hotClient.callTool('search', {}); // refresh hot
+
+    now += 40_000; // hot idle 40s, cold idle 70s
+    const manager = new MultiServerMcpManager({ hot: hotClient, cold: coldClient });
+
+    const evicted = await manager.sweepIdle();
+    expect(evicted).toEqual(['cold']);
+    expect(hotClient.isDisposed()).toBe(false);
+    expect(coldClient.isDisposed()).toBe(true);
+  });
+
+  it('MultiServerMcpManager.disposeAll tears every server down', async () => {
+    const a = makeFakeTransport();
+    const b = makeFakeTransport();
+    const manager = new MultiServerMcpManager({
+      a: new McpClient(a),
+      b: new McpClient(b),
+    });
+    await manager.disposeAll();
+    expect(a.disconnect).toHaveBeenCalledTimes(1);
+    expect(b.disconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+// =============================================================================
+// #81 — providers plugin manifest cold-read
+// =============================================================================
+
+describe('#81 providers plugin manifest cold-read', () => {
+  const sampleEntry = {
+    id: 'cold-model',
+    contextLength: 256_000,
+    supportsTools: true,
+    supportsImages: false,
+    supportsStreaming: true,
+  };
+
+  it('readPluginManifestModelCatalog parses a valid plugin manifest', () => {
+    const manifest = {
+      name: 'crowclaw-model-pack',
+      modelCatalog: {
+        updatedAt: '2026-04-27',
+        models: [sampleEntry],
+      },
+    };
+    const parsed = readPluginManifestModelCatalog(manifest);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.models).toHaveLength(1);
+    expect(parsed?.models[0]?.id).toBe('cold-model');
+    expect(parsed?.updatedAt).toBe('2026-04-27');
+  });
+
+  it('returns null when modelCatalog is missing', () => {
+    expect(readPluginManifestModelCatalog({ name: 'bare' })).toBeNull();
+    expect(readPluginManifestModelCatalog(null)).toBeNull();
+    expect(readPluginManifestModelCatalog(undefined)).toBeNull();
+  });
+
+  it('filters out malformed entries instead of throwing', () => {
+    const manifest = {
+      modelCatalog: {
+        models: [
+          sampleEntry,
+          { id: 'bad', contextLength: 'not-a-number' },
+          { id: 42 }, // wrong type
+          null,
+          { ...sampleEntry, id: 'second-good' },
+        ],
+      },
+    };
+    const parsed = readPluginManifestModelCatalog(manifest);
+    expect(parsed?.models.map((m) => m.id)).toEqual(['cold-model', 'second-good']);
+  });
+
+  it('hasPluginManifestModelCatalog narrows correctly', () => {
+    expect(hasPluginManifestModelCatalog({ modelCatalog: { models: [] } })).toBe(true);
+    expect(hasPluginManifestModelCatalog({ modelCatalog: { models: 'nope' } })).toBe(false);
+    expect(hasPluginManifestModelCatalog({})).toBe(false);
+  });
+
+  it('seedManifestCacheFromPlugin makes the next loadManifest cold-read from cache', async () => {
+    const cache: ManifestCache = new Map();
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        updatedAt: '2099-01-01',
+        models: [
+          {
+            id: 'remote-only',
+            contextLength: 1,
+            supportsTools: false,
+            supportsImages: false,
+            supportsStreaming: false,
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const seeded = seedManifestCacheFromPlugin(
+      { modelCatalog: { models: [sampleEntry], updatedAt: '2026-04-27' } },
+      { cache, url: DEFAULT_MANIFEST_URL },
+    );
+    expect(seeded).toBe(true);
+
+    // Cold read — must serve from cache and avoid the network round-trip.
+    const manifest = await loadManifest(DEFAULT_MANIFEST_URL, cache);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(manifest.models[0]?.id).toBe('cold-model');
+  });
+
+  it('seedManifestCacheFromPlugin returns false when the manifest has no catalog', () => {
+    const cache: ManifestCache = new Map();
+    expect(seedManifestCacheFromPlugin({ name: 'no-catalog' }, { cache })).toBe(false);
+    expect(cache.size).toBe(0);
+  });
+
+  it('does not interfere with the default cache when a fresh Map is passed', () => {
+    resetManifestCache();
+    const cache: ManifestCache = new Map();
+    seedManifestCacheFromPlugin(
+      { modelCatalog: { models: [sampleEntry] } },
+      { cache },
+    );
+    expect(cache.size).toBe(1);
+  });
+});
+
+// =============================================================================
+// #103 — stdio-transport exponential-backoff reconnect
+// =============================================================================
+
+describe('#103 stdio-transport exponential-backoff reconnect', () => {
+  /**
+   * Drive `maybeScheduleReconnect` directly in unit tests. We stub `connect`
+   * to a no-op so the timer firing doesn't try to spawn anything, and we
+   * also clear the timer slot ourselves between manual invocations to
+   * simulate sequential close events.
+   */
+  function driveTransport(transport: McpJsonRpcStdioTransport) {
+    const internal = transport as unknown as {
+      maybeScheduleReconnect: () => void;
+      reconnectTimer: ReturnType<typeof setTimeout> | null;
+      connect: () => Promise<void>;
+    };
+    // Replace connect with a no-op to keep the test hermetic.
+    internal.connect = async () => {};
+    return internal;
+  }
+
+  it('schedules reconnect with 1s/2s/4s backoff after unexpected close', () => {
+    vi.useFakeTimers();
+    const onReconnect = vi.fn();
+    const transport = new McpJsonRpcStdioTransport(
+      { command: 'noop' },
+      { autoReconnect: true, onReconnect },
+    );
+    const internal = driveTransport(transport);
+
+    internal.maybeScheduleReconnect();
+    expect(onReconnect).toHaveBeenLastCalledWith(1, 1000);
+
+    vi.advanceTimersByTime(1000); // fires (no-op connect), clears timer slot
+    internal.maybeScheduleReconnect();
+    expect(onReconnect).toHaveBeenLastCalledWith(2, 2000);
+
+    vi.advanceTimersByTime(2000);
+    internal.maybeScheduleReconnect();
+    expect(onReconnect).toHaveBeenLastCalledWith(3, 4000);
+  });
+
+  it('caps at reconnectMaxAttempts (default 3)', () => {
+    vi.useFakeTimers();
+    const onReconnect = vi.fn();
+    const transport = new McpJsonRpcStdioTransport(
+      { command: 'noop' },
+      { autoReconnect: true, onReconnect, reconnectMaxAttempts: 3 },
+    );
+    const internal = driveTransport(transport);
+
+    for (let i = 0; i < 5; i++) {
+      internal.maybeScheduleReconnect();
+      vi.advanceTimersByTime(10_000); // flush whatever was scheduled
+    }
+
+    expect(onReconnect).toHaveBeenCalledTimes(3);
+    expect(onReconnect.mock.calls.map((c) => c[0])).toEqual([1, 2, 3]);
+  });
+
+  it('does not schedule when autoReconnect is false', () => {
+    vi.useFakeTimers();
+    const onReconnect = vi.fn();
+    const transport = new McpJsonRpcStdioTransport(
+      { command: 'noop' },
+      { autoReconnect: false, onReconnect },
+    );
+    const internal = driveTransport(transport);
+    internal.maybeScheduleReconnect();
+    expect(onReconnect).not.toHaveBeenCalled();
+  });
+
+  it('disconnect() suppresses any scheduled reconnect', async () => {
+    vi.useFakeTimers();
+    const onReconnect = vi.fn();
+    const transport = new McpJsonRpcStdioTransport(
+      { command: 'noop' },
+      { autoReconnect: true, onReconnect },
+    );
+    const internal = driveTransport(transport);
+    internal.maybeScheduleReconnect();
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+
+    // disconnect() returns early because !connected, but it must still
+    // cancel the pending reconnect timer and set disconnectRequested.
+    await transport.disconnect();
+
+    vi.advanceTimersByTime(10_000);
+    internal.maybeScheduleReconnect();
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours custom reconnectInitialDelayMs', () => {
+    vi.useFakeTimers();
+    const onReconnect = vi.fn();
+    const transport = new McpJsonRpcStdioTransport(
+      { command: 'noop' },
+      { autoReconnect: true, onReconnect, reconnectInitialDelayMs: 250 },
+    );
+    const internal = driveTransport(transport);
+    internal.maybeScheduleReconnect();
+    expect(onReconnect).toHaveBeenLastCalledWith(1, 250);
+
+    vi.advanceTimersByTime(250);
+    internal.maybeScheduleReconnect();
+    expect(onReconnect).toHaveBeenLastCalledWith(2, 500);
+  });
+});
+
+// =============================================================================
+// #148 — AcpServer tools/list registry callback
+// =============================================================================
+
+describe('#148 AcpServer tools/list registry callback', () => {
+  const noopLoop = {
+    run: async () => ({ finalResponse: '', toolResults: [] }),
+  };
+
+  it('returns available=false when no tools callback is wired', async () => {
+    const server = new AcpServer(noopLoop);
+    const response = await server.handleRequest({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    });
+    expect(response.error).toBeUndefined();
+    expect(response.result).toEqual({ tools: [], available: false });
+  });
+
+  it('returns available=true and the registry tools when wired', async () => {
+    const tools: AcpToolInfo[] = [
+      { name: 'web.search', description: 'Search the web' },
+      { name: 'fs.read', description: 'Read a file', inputSchema: { type: 'object' } },
+    ];
+    const server = new AcpServer(noopLoop, { tools: () => tools });
+
+    const response = await server.handleRequest({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    });
+    expect(response.result).toEqual({ tools, available: true });
+  });
+
+  it('supports async tool callbacks', async () => {
+    const tools: AcpToolInfo[] = [{ name: 'late.tool' }];
+    const server = new AcpServer(noopLoop, {
+      tools: async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        return tools;
+      },
+    });
+    const response = await server.handleRequest({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/list',
+    });
+    expect(response.result).toEqual({ tools, available: true });
+  });
+
+  it('catches callback errors and reports available=false with an error message', async () => {
+    const server = new AcpServer(noopLoop, {
+      tools: () => {
+        throw new Error('registry offline');
+      },
+    });
+    const response = await server.handleRequest({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/list',
+    });
+    expect(response.error).toBeUndefined();
+    const result = response.result as { tools: unknown[]; available: boolean; error?: string };
+    expect(result.available).toBe(false);
+    expect(result.tools).toEqual([]);
+    expect(result.error).toMatch(/registry offline/);
+  });
+});

--- a/tests/v06_1-runtime-node-shutdown.test.ts
+++ b/tests/v06_1-runtime-node-shutdown.test.ts
@@ -1,0 +1,428 @@
+/**
+ * v0.6.1 reliability + security sweep — runtime-node shutdown / body cap.
+ *
+ * Covers:
+ * - #115 wsManager.stop() called in shutdown()
+ * - #116 bridgeProcesses Map cleanup on terminate + prune dead entries
+ * - #118 lastHeartbeatAt EventBus listener unsubscribed in shutdown
+ * - #119 contextRefresh interval cleared in shutdown
+ * - #120 GatewayDebouncer.flush() called in shutdown
+ * - #123 child handle.removeAllListeners + null on terminate
+ * - #124 RateLimiter eviction off-by-one when oldest === current key
+ * - #128 1 MiB body size cap on POST routes (with chunked-stream defense)
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  createNodeRuntime,
+  GatewayDebouncer,
+  RateLimiter,
+  MAX_REQUEST_BODY_BYTES,
+  checkContentLengthCap,
+  readJsonWithSizeCap,
+} from '../packages/runtime-node/src/index.js';
+import {
+  terminateBridgeProcess,
+  pruneDeadBridgeProcesses,
+  type BridgeProcessRecord,
+} from '../packages/runtime-node/src/bridge-process.js';
+import { EchoProvider } from '@crowclaw/providers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FakeChildHandle {
+  pid?: number;
+  killed: boolean;
+  listenersByEvent: Map<string, Array<(code: number | null) => void>>;
+  removeAllCalled: number;
+  killCalls: number;
+  kill(_signal?: string): boolean;
+  on(event: string, cb: (code: number | null) => void): void;
+  removeAllListeners(event?: string): void;
+  unref(): void;
+}
+
+function makeFakeHandle(): FakeChildHandle {
+  const handle: FakeChildHandle = {
+    pid: 99999,
+    killed: false,
+    listenersByEvent: new Map(),
+    removeAllCalled: 0,
+    killCalls: 0,
+    kill(_signal?: string) {
+      this.killed = true;
+      this.killCalls += 1;
+      return true;
+    },
+    on(event, cb) {
+      const arr = this.listenersByEvent.get(event) ?? [];
+      arr.push(cb);
+      this.listenersByEvent.set(event, arr);
+    },
+    removeAllListeners(event?: string) {
+      this.removeAllCalled += 1;
+      if (event) this.listenersByEvent.delete(event);
+      else this.listenersByEvent.clear();
+    },
+    unref() { /* noop */ },
+  };
+  return handle;
+}
+
+function makeBridgeRecord(sessionId: string, alive = true, startedAt = new Date().toISOString()): BridgeProcessRecord & { handle: FakeChildHandle } {
+  const handle = makeFakeHandle();
+  handle.on('exit', () => { /* noop */ });
+  // pruneDeadBridgeProcesses only collects records that ACTUALLY ran and then
+  // exited (have exitedAt). Simulated / spawn-error records (alive=false from
+  // birth, no exitedAt) stay visible. Tests for the dead-and-cleaned path must
+  // stamp exitedAt alongside alive=false to model a real terminated process.
+  return {
+    sessionId,
+    protocolVersion: 'crowclaw-tool-bridge/v1',
+    pid: handle.pid,
+    command: 'fake',
+    mode: 'child-process',
+    socketPath: `/tmp/${sessionId}.sock`,
+    socketReady: true,
+    supportedDirectTools: ['echo'],
+    alive,
+    startedAt,
+    handle,
+    ...(alive ? {} : { exitedAt: new Date().toISOString(), exitCode: 0 }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// #115 / #118 / #119 / #120 — shutdown wiring
+// ---------------------------------------------------------------------------
+
+describe('createNodeRuntime shutdown (#115/#118/#119/#120)', () => {
+  it('runs to completion without throwing and reports drained debouncer count', async () => {
+    const runtime = createNodeRuntime({ provider: new EchoProvider() });
+    const summary = await runtime.shutdown();
+    expect(summary).toBeDefined();
+    expect(typeof summary.ssEClosed).toBe('number');
+    expect(typeof summary.learningAwaited).toBe('number');
+    expect(typeof summary.debouncerFlushed).toBe('number');
+    expect(summary.debouncerFlushed).toBe(0);
+  });
+
+  it('is idempotent — calling shutdown twice does not throw', async () => {
+    const runtime = createNodeRuntime({ provider: new EchoProvider() });
+    await runtime.shutdown();
+    await expect(runtime.shutdown()).resolves.toBeDefined();
+  });
+
+  it('back-to-back createNodeRuntime() does not leave the process pinned', async () => {
+    // If wsManager.stop / contextRefresh / heartbeat-tracker leaked, the
+    // intervals would still keep firing — we can't easily prove "no extra
+    // intervals" from inside the runtime, but we can at least prove that
+    // shutting down two consecutive runtimes succeeds and reports clean
+    // counts. This guards against regressions where the second runtime
+    // can't shut down because the first one's listeners are still wired.
+    const a = createNodeRuntime({ provider: new EchoProvider() });
+    const b = createNodeRuntime({ provider: new EchoProvider() });
+    await a.shutdown();
+    await b.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #120 — GatewayDebouncer.flush
+// ---------------------------------------------------------------------------
+
+describe('GatewayDebouncer.flush (#120)', () => {
+  it('drains pending entries and resolves their promises with merged text', async () => {
+    const d = new GatewayDebouncer(10_000);
+    const p = d.debounce('discord', 'u1', 'c1', 'hello');
+    expect(d.pendingCount).toBe(1);
+    const drained = d.flush();
+    expect(drained).toBe(1);
+    expect(d.pendingCount).toBe(0);
+    await expect(p).resolves.toBe('hello');
+  });
+
+  it('returns 0 when nothing is pending', () => {
+    const d = new GatewayDebouncer(10_000);
+    expect(d.flush()).toBe(0);
+  });
+
+  it('handles multiple pending entries across distinct keys', async () => {
+    const d = new GatewayDebouncer(10_000);
+    const a = d.debounce('discord', 'u1', 'c1', 'a');
+    const b = d.debounce('telegram', 'u2', 'c2', 'b');
+    expect(d.pendingCount).toBe(2);
+    expect(d.flush()).toBe(2);
+    await expect(a).resolves.toBe('a');
+    await expect(b).resolves.toBe('b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #124 — RateLimiter eviction off-by-one
+// ---------------------------------------------------------------------------
+
+describe('RateLimiter eviction (#124)', () => {
+  it('does not exceed maxKeys when the oldest key happens to be the current key', () => {
+    const rl = new RateLimiter({ maxKeys: 2 });
+    expect(rl.check('a', 100, 60_000)).toBe(true);
+    expect(rl.check('b', 100, 60_000)).toBe(true);
+    // Third distinct key inserts at size=3, then evicts down to 2.
+    expect(rl.check('c', 100, 60_000)).toBe(true);
+    expect(rl.size).toBe(2);
+    // Re-checking 'a' (which was likely evicted) inserts again, growing
+    // to 3 then evicting back to 2 — never to 3.
+    expect(rl.check('a', 100, 60_000)).toBe(true);
+    expect(rl.size).toBe(2);
+  });
+
+  it('caps the Map size after many distinct keys', () => {
+    const rl = new RateLimiter({ maxKeys: 3 });
+    for (let i = 0; i < 50; i++) {
+      rl.check(`key-${i}`, 100, 60_000);
+    }
+    expect(rl.size).toBe(3);
+  });
+
+  it('never evicts the entry just inserted', () => {
+    const rl = new RateLimiter({ maxKeys: 1 });
+    rl.check('first', 100, 60_000);
+    rl.check('second', 100, 60_000);
+    expect(rl.size).toBe(1);
+    // 'second' must still be tracked — if eviction picked the just-inserted
+    // key the size would be 0 here, or the next call to 'second' would
+    // re-insert it as if it were a fresh client (silently doubling allowance).
+    expect(rl.check('second', 1, 60_000)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #116 / #123 — bridge process termination + prune
+// ---------------------------------------------------------------------------
+
+describe('terminateBridgeProcess (#116/#123)', () => {
+  it('removes the entry from the Map after terminate', () => {
+    const map = new Map<string, BridgeProcessRecord>();
+    const rec = makeBridgeRecord('s1');
+    map.set('s1', rec);
+    terminateBridgeProcess(map, 's1');
+    expect(map.has('s1')).toBe(false);
+    expect(map.size).toBe(0);
+  });
+
+  it('detaches all child-process listeners and nulls the handle', () => {
+    const map = new Map<string, BridgeProcessRecord>();
+    const rec = makeBridgeRecord('s2');
+    const handle = rec.handle as FakeChildHandle;
+    map.set('s2', rec);
+    const out = terminateBridgeProcess(map, 's2');
+    expect(out).toBeDefined();
+    expect(handle.removeAllCalled).toBeGreaterThanOrEqual(1);
+    expect(handle.listenersByEvent.size).toBe(0);
+    // The record returned by terminate had its handle nulled.
+    expect(out!.handle).toBeNull();
+  });
+
+  it('returns undefined for unknown sessionId', () => {
+    const map = new Map<string, BridgeProcessRecord>();
+    expect(terminateBridgeProcess(map, 'nope')).toBeUndefined();
+  });
+
+  it('does not throw when the handle has no removeAllListeners (legacy shape)', () => {
+    const map = new Map<string, BridgeProcessRecord>();
+    map.set('s3', {
+      sessionId: 's3',
+      protocolVersion: 'v1',
+      command: 'x',
+      mode: 'simulated',
+      socketPath: '/tmp/x.sock',
+      socketReady: false,
+      supportedDirectTools: [],
+      alive: false,
+      startedAt: new Date().toISOString(),
+    });
+    expect(() => terminateBridgeProcess(map, 's3')).not.toThrow();
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('pruneDeadBridgeProcesses (#116)', () => {
+  it('removes entries whose alive flag is false', () => {
+    const map = new Map<string, BridgeProcessRecord>();
+    map.set('a', makeBridgeRecord('a', false));
+    map.set('b', makeBridgeRecord('b', true));
+    map.set('c', makeBridgeRecord('c', false));
+    const removed = pruneDeadBridgeProcesses(map);
+    expect(removed).toBe(2);
+    expect(map.size).toBe(1);
+    expect(map.has('b')).toBe(true);
+  });
+
+  it('removes entries whose startedAt is older than maxAgeMs', () => {
+    const map = new Map<string, BridgeProcessRecord>();
+    const oldTime = new Date(Date.now() - 7_200_000).toISOString(); // 2h old
+    map.set('old', makeBridgeRecord('old', true, oldTime));
+    map.set('young', makeBridgeRecord('young', true));
+    const removed = pruneDeadBridgeProcesses(map, 60 * 60 * 1000);
+    expect(removed).toBe(1);
+    expect(map.has('old')).toBe(false);
+    expect(map.has('young')).toBe(true);
+  });
+
+  it('handles 100 spawn-then-terminate cycles without leaking the Map', () => {
+    const map = new Map<string, BridgeProcessRecord>();
+    for (let i = 0; i < 100; i++) {
+      map.set(`s${i}`, makeBridgeRecord(`s${i}`));
+    }
+    expect(map.size).toBe(100);
+    for (let i = 0; i < 100; i++) {
+      terminateBridgeProcess(map, `s${i}`);
+    }
+    expect(map.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #128 — 1 MiB body size cap
+// ---------------------------------------------------------------------------
+
+describe('checkContentLengthCap (#128)', () => {
+  it('returns null when content-length is absent', () => {
+    const req = new Request('http://localhost/x', { method: 'POST' });
+    expect(checkContentLengthCap(req)).toBeNull();
+  });
+
+  it('returns null for sizes within the cap', () => {
+    const req = new Request('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-length': '1024' },
+      body: 'small body',
+    });
+    expect(checkContentLengthCap(req)).toBeNull();
+  });
+
+  it('returns 413 when content-length exceeds the cap', () => {
+    const tooBig = String(MAX_REQUEST_BODY_BYTES + 1);
+    const req = new Request('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-length': tooBig },
+    });
+    const res = checkContentLengthCap(req);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(413);
+  });
+
+  it('returns 400 when content-length is malformed', () => {
+    const req = new Request('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-length': 'not-a-number' },
+    });
+    const res = checkContentLengthCap(req);
+    expect(res!.status).toBe(400);
+  });
+});
+
+describe('readJsonWithSizeCap (#128)', () => {
+  it('parses a small JSON body normally', async () => {
+    const req = new Request('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ a: 1 }),
+    });
+    const out = await readJsonWithSizeCap<{ a: number }>(req);
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.value.a).toBe(1);
+  });
+
+  it('rejects a body whose declared content-length exceeds the cap before reading', async () => {
+    const tooBig = String(MAX_REQUEST_BODY_BYTES + 1);
+    // We can't easily construct a real oversized stream — the header gate
+    // alone is enough for this test. The streaming gate is exercised below
+    // with a synthetic ReadableStream that omits the header.
+    const req = new Request('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-length': tooBig, 'content-type': 'application/json' },
+      body: JSON.stringify({ a: 1 }),
+    });
+    const out = await readJsonWithSizeCap(req);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.response.status).toBe(413);
+  });
+
+  it('aborts a chunked stream that exceeds the cap (no Content-Length)', async () => {
+    // Build a ReadableStream that streams >1 MiB without setting a header.
+    const chunk = new Uint8Array(64 * 1024); // 64 KiB
+    chunk.fill(0x61); // 'a'
+    let pushed = 0;
+    const totalToPush = MAX_REQUEST_BODY_BYTES + 256 * 1024; // 1.25 MiB
+
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pushed >= totalToPush) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk);
+        pushed += chunk.byteLength;
+      },
+    });
+
+    const req = new Request('http://localhost/x', {
+      method: 'POST',
+      // Deliberately no content-length — simulates chunked transfer.
+      body: stream,
+      // @ts-expect-error — undici needs duplex for streaming bodies.
+      duplex: 'half',
+    });
+    const out = await readJsonWithSizeCap(req);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.response.status).toBe(413);
+  });
+
+  it('returns 400 when the body is not valid JSON', async () => {
+    const req = new Request('http://localhost/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not json {',
+    });
+    const out = await readJsonWithSizeCap(req);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.response.status).toBe(400);
+  });
+});
+
+describe('runtime fetch — body size cap (#128)', () => {
+  it('rejects a POST whose content-length exceeds the cap', async () => {
+    const runtime = createNodeRuntime({ provider: new EchoProvider() });
+    const tooBig = String(MAX_REQUEST_BODY_BYTES + 1);
+    const res = await runtime.fetch(new Request('http://localhost/api/auth/verify', {
+      method: 'POST',
+      headers: { 'content-length': tooBig, 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'whatever' }),
+    }));
+    expect(res.status).toBe(413);
+  });
+
+  it('still accepts a normal-sized auth/verify POST', async () => {
+    const runtime = createNodeRuntime({ provider: new EchoProvider() });
+    const res = await runtime.fetch(new Request('http://localhost/api/auth/verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'wrong' }),
+    }));
+    // Either 200 ({ok:false}) or 429 if previous tests in the file
+    // pre-warmed the rate limiter; both prove it didn't 413.
+    expect(res.status).not.toBe(413);
+  });
+
+  it('rejects a POST with a malformed content-length header', async () => {
+    const runtime = createNodeRuntime({ provider: new EchoProvider() });
+    const res = await runtime.fetch(new Request('http://localhost/api/auth/verify', {
+      method: 'POST',
+      headers: { 'content-length': 'banana', 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'x' }),
+    }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/v06_1-tools-memory.test.ts
+++ b/tests/v06_1-tools-memory.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ToolRegistry,
+  createWorkspaceReadTool,
+  WORKSPACE_READ_DEDUP_LIMIT,
+  resetWorkspaceReadDedup,
+  getWorkspaceReadDedupCount,
+  withApproval,
+  requestApproval,
+  type ApprovalCallback,
+} from '../packages/tools/src/index.js';
+import {
+  MemoryManager,
+  type MemoryProvider,
+  type ManagerMemoryRecord,
+  type SessionTranscriptMessage,
+} from '../packages/memory/src/index.js';
+import type { ToolExecutionContext, ToolDefinition, ToolExecutionResult } from '../packages/core/src/index.js';
+import { InMemoryWorkspaceStore, type WorkspaceStore } from '../packages/workspace/src/index.js';
+
+/**
+ * v0.6.1 regression suite for the tools + memory ownership block.
+ *
+ *  - #85   MemoryManager.shutdown forwards the live transcript to providers'
+ *          onSessionEnd hook (was passing `[]` and silently disabling
+ *          dream-memory live capture and end-of-session summarisation).
+ *  - #86   ToolRegistry.execute snapshots the approval callback per dispatch
+ *          so concurrent `Promise.all` tool workers see a stable reference
+ *          even when the parent context is mutated mid-flight.
+ *  - #88   `workspace.read` escalates dedup-stub repetition to a synthetic
+ *          BLOCKED result after WORKSPACE_READ_DEDUP_LIMIT (3) reads of the
+ *          same path within a session.
+ */
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+async function createInMemoryWorkspace(
+  files: Record<string, string> = {},
+): Promise<WorkspaceStore> {
+  const store = new InMemoryWorkspaceStore();
+  for (const [path, content] of Object.entries(files)) {
+    await store.write(path, content);
+  }
+  return store;
+}
+
+function createContext(sessionId: string): ToolExecutionContext {
+  return {
+    agentId: 'test-agent',
+    sessionId,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// #85 — MemoryManager.shutdown forwards transcript to onSessionEnd
+// -----------------------------------------------------------------------------
+
+describe('#85 MemoryManager.shutdown forwards transcript', () => {
+  function createCapturingProvider(
+    name: string,
+    options: { throws?: boolean } = {},
+  ): MemoryProvider & { calls: Array<{ sessionId: string; messages: SessionTranscriptMessage[] }> } {
+    const calls: Array<{ sessionId: string; messages: SessionTranscriptMessage[] }> = [];
+    return {
+      name,
+      calls,
+      async store(): Promise<void> {},
+      async recall(): Promise<ManagerMemoryRecord[]> { return []; },
+      async forget(): Promise<boolean> { return true; },
+      async onSessionEnd(sessionId, messages): Promise<void> {
+        calls.push({ sessionId, messages });
+        if (options.throws) {
+          throw new Error(`${name} blew up`);
+        }
+      },
+    };
+  }
+
+  it('passes the live transcript (not []) to every provider with onSessionEnd', async () => {
+    const manager = new MemoryManager();
+    const a = createCapturingProvider('a');
+    const b = createCapturingProvider('b');
+    manager.addProvider(a);
+    manager.addProvider(b);
+
+    const transcript: SessionTranscriptMessage[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi there' },
+    ];
+    const results = await manager.shutdown('session-42', transcript);
+
+    expect(a.calls).toHaveLength(1);
+    expect(b.calls).toHaveLength(1);
+    expect(a.calls[0]?.sessionId).toBe('session-42');
+    expect(a.calls[0]?.messages).toHaveLength(2);
+    expect(a.calls[0]?.messages[0]?.content).toBe('hello');
+    expect(a.calls[0]?.messages).not.toEqual([]);
+
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.invoked && r.ok)).toBe(true);
+  });
+
+  it('skips providers without an onSessionEnd hook (invoked=false, ok=true)', async () => {
+    const manager = new MemoryManager();
+    const minimal: MemoryProvider = {
+      name: 'minimal',
+      async store(): Promise<void> {},
+      async recall(): Promise<ManagerMemoryRecord[]> { return []; },
+      async forget(): Promise<boolean> { return true; },
+    };
+    manager.addProvider(minimal);
+
+    const results = await manager.shutdown('session-1', [
+      { role: 'user', content: 'noop' },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ provider: 'minimal', invoked: false, ok: true });
+  });
+
+  it('isolates per-provider failures so one bad backend cannot abort the rest', async () => {
+    const manager = new MemoryManager();
+    const good = createCapturingProvider('good');
+    const bad = createCapturingProvider('bad', { throws: true });
+    manager.addProvider(bad);
+    manager.addProvider(good);
+
+    const results = await manager.shutdown('s1', [{ role: 'user', content: 'x' }]);
+
+    expect(results).toHaveLength(2);
+    const goodResult = results.find((r) => r.provider === 'good');
+    const badResult = results.find((r) => r.provider === 'bad');
+    expect(goodResult).toMatchObject({ invoked: true, ok: true });
+    expect(badResult).toMatchObject({ invoked: true, ok: false });
+    expect(badResult?.error).toContain('bad blew up');
+    // The "good" provider must still have been called even though "bad" threw.
+    expect(good.calls).toHaveLength(1);
+  });
+
+  it('coerces a non-array `messages` argument to [] without throwing (defensive)', async () => {
+    const manager = new MemoryManager();
+    const provider = createCapturingProvider('p');
+    manager.addProvider(provider);
+
+    // Simulate a host bug that passes `undefined` instead of session.messages.
+    const results = await manager.shutdown(
+      's1',
+      undefined as unknown as SessionTranscriptMessage[],
+    );
+
+    expect(results[0]?.ok).toBe(true);
+    expect(provider.calls[0]?.messages).toEqual([]);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// #86 — Approval callback survives concurrent dispatch
+// -----------------------------------------------------------------------------
+
+describe('#86 ToolRegistry approval propagation under Promise.all', () => {
+  /**
+   * Tool that *demands* the approval callback be reachable; otherwise it
+   * fails. Lets us exercise the gate without going through AgentLoop.
+   */
+  function approvalProbeTool(): ToolDefinition {
+    return {
+      manifest: {
+        name: 'test.approvalProbe',
+        description: 'Probe that calls the approval callback to verify reachability.',
+        runtime: 'worker',
+        streaming: false,
+        stateful: false,
+        requiresWorkspace: false,
+        requiresNetwork: false,
+        dangerLevel: 'low',
+        inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
+      async execute(input, context): Promise<ToolExecutionResult> {
+        const ok = await requestApproval(context, 'test.approvalProbe', input);
+        return {
+          toolName: 'test.approvalProbe',
+          runtime: 'worker',
+          ok,
+          output: ok ? 'approved' : 'no-callback',
+          metadata: { id: input.id },
+        };
+      },
+    };
+  }
+
+  it('every concurrent worker sees the approval callback', async () => {
+    const registry = new ToolRegistry();
+    registry.register(approvalProbeTool());
+
+    const callCounts: string[] = [];
+    const callback: ApprovalCallback = async (req) => {
+      callCounts.push(String(req.input.id));
+      return true;
+    };
+    const baseCtx = withApproval(createContext('s-concurrent'), callback);
+
+    // Fan out 5 concurrent dispatches sharing the same source context — this
+    // is the AgentLoop safety-partition pattern that #86 broke.
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        registry.execute('test.approvalProbe', { id: `t${i}` }, baseCtx),
+      ),
+    );
+
+    expect(results.map((r) => r.ok)).toEqual([true, true, true, true, true]);
+    expect(results.map((r) => r.output)).toEqual([
+      'approved', 'approved', 'approved', 'approved', 'approved',
+    ]);
+    expect(callCounts).toHaveLength(5);
+    expect(new Set(callCounts)).toEqual(new Set(['t0', 't1', 't2', 't3', 't4']));
+  });
+
+  it('a parent that mutates context.approval mid-flight cannot disable an in-flight worker', async () => {
+    const registry = new ToolRegistry();
+    registry.register(approvalProbeTool());
+
+    let callbackInvocations = 0;
+    const callback: ApprovalCallback = async () => {
+      callbackInvocations++;
+      // Yield so the test can race a mutation against the in-flight call.
+      await new Promise((r) => setTimeout(r, 10));
+      return true;
+    };
+    const sourceCtx = withApproval(createContext('s-mutation'), callback) as
+      ToolExecutionContext & { approval?: ApprovalCallback };
+
+    const dispatchPromise = registry.execute('test.approvalProbe', { id: 'one' }, sourceCtx);
+    // Simulate a teardown hook that wipes `approval` on the shared context
+    // immediately after dispatch — without the per-dispatch snapshot, the
+    // probe would observe `undefined` and report `no-callback`.
+    sourceCtx.approval = undefined;
+
+    const result = await dispatchPromise;
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe('approved');
+    expect(callbackInvocations).toBe(1);
+  });
+
+  it('reports no-callback when no approval is wired (graceful degradation)', async () => {
+    const registry = new ToolRegistry();
+    registry.register(approvalProbeTool());
+    const result = await registry.execute(
+      'test.approvalProbe',
+      { id: 'x' },
+      createContext('s-no-cb'),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.output).toBe('no-callback');
+  });
+
+  it('requestApproval returns false (fail-closed) when the callback throws', async () => {
+    const registry = new ToolRegistry();
+    registry.register(approvalProbeTool());
+    const ctx = withApproval(createContext('s-throw'), async () => {
+      throw new Error('operator denied');
+    });
+    const result = await registry.execute('test.approvalProbe', { id: 'x' }, ctx);
+    expect(result.ok).toBe(false);
+    expect(result.output).toBe('no-callback');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// #88 — workspace.read dedup-stub escalates to BLOCKED
+// -----------------------------------------------------------------------------
+
+describe('#88 workspace.read dedup escalation', () => {
+  beforeEach(() => {
+    resetWorkspaceReadDedup();
+  });
+
+  it(`allows the first ${WORKSPACE_READ_DEDUP_LIMIT} reads of the same path`, async () => {
+    const workspace = await createInMemoryWorkspace({ 'a.md': 'hello' });
+    const tool = createWorkspaceReadTool(workspace);
+    const ctx = createContext('s-1');
+
+    for (let i = 0; i < WORKSPACE_READ_DEDUP_LIMIT; i++) {
+      const result = await tool.execute({ path: 'a.md' }, ctx);
+      expect(result.ok).toBe(true);
+      expect(result.output).toBe('hello');
+      expect(result.metadata?.['tool:blocked_dedup']).toBeUndefined();
+    }
+    expect(getWorkspaceReadDedupCount('s-1', 'a.md')).toBe(WORKSPACE_READ_DEDUP_LIMIT);
+  });
+
+  it(`returns BLOCKED with tool:blocked_dedup on the (limit+1)th read`, async () => {
+    const workspace = await createInMemoryWorkspace({ 'a.md': 'hello' });
+    const tool = createWorkspaceReadTool(workspace);
+    const ctx = createContext('s-2');
+
+    for (let i = 0; i < WORKSPACE_READ_DEDUP_LIMIT; i++) {
+      await tool.execute({ path: 'a.md' }, ctx);
+    }
+    const result = await tool.execute({ path: 'a.md' }, ctx);
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain('BLOCKED');
+    expect(result.output).toContain('a.md');
+    expect(result.metadata?.['tool:blocked_dedup']).toBe(true);
+    expect(result.metadata?.blocked).toBe(true);
+    expect(result.metadata?.path).toBe('a.md');
+    expect(result.metadata?.limit).toBe(WORKSPACE_READ_DEDUP_LIMIT);
+  });
+
+  it('counts are isolated per session', async () => {
+    const workspace = await createInMemoryWorkspace({ 'a.md': 'hello' });
+    const tool = createWorkspaceReadTool(workspace);
+
+    // Saturate session 1
+    for (let i = 0; i < WORKSPACE_READ_DEDUP_LIMIT; i++) {
+      await tool.execute({ path: 'a.md' }, createContext('s-1'));
+    }
+    const blocked = await tool.execute({ path: 'a.md' }, createContext('s-1'));
+    expect(blocked.metadata?.['tool:blocked_dedup']).toBe(true);
+
+    // Different session must still pass
+    const fresh = await tool.execute({ path: 'a.md' }, createContext('s-2'));
+    expect(fresh.ok).toBe(true);
+    expect(fresh.metadata?.['tool:blocked_dedup']).toBeUndefined();
+  });
+
+  it('counts are isolated per path', async () => {
+    const workspace = await createInMemoryWorkspace({ 'a.md': 'hello', 'b.md': 'world' });
+    const tool = createWorkspaceReadTool(workspace);
+    const ctx = createContext('s-paths');
+
+    for (let i = 0; i < WORKSPACE_READ_DEDUP_LIMIT; i++) {
+      await tool.execute({ path: 'a.md' }, ctx);
+    }
+    // a.md is at the limit, but b.md is a fresh path.
+    const result = await tool.execute({ path: 'b.md' }, ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe('world');
+  });
+
+  it('resetWorkspaceReadDedup(sessionId) clears only that session', async () => {
+    const workspace = await createInMemoryWorkspace({ 'a.md': 'hello' });
+    const tool = createWorkspaceReadTool(workspace);
+
+    for (let i = 0; i < WORKSPACE_READ_DEDUP_LIMIT; i++) {
+      await tool.execute({ path: 'a.md' }, createContext('s-A'));
+      await tool.execute({ path: 'a.md' }, createContext('s-B'));
+    }
+    resetWorkspaceReadDedup('s-A');
+    expect(getWorkspaceReadDedupCount('s-A', 'a.md')).toBe(0);
+    expect(getWorkspaceReadDedupCount('s-B', 'a.md')).toBe(WORKSPACE_READ_DEDUP_LIMIT);
+
+    const a = await tool.execute({ path: 'a.md' }, createContext('s-A'));
+    const b = await tool.execute({ path: 'a.md' }, createContext('s-B'));
+    expect(a.ok).toBe(true);
+    expect(b.metadata?.['tool:blocked_dedup']).toBe(true);
+  });
+
+  it('rejects missing path with a clear error (does not increment the dedup counter)', async () => {
+    const workspace = await createInMemoryWorkspace({});
+    const tool = createWorkspaceReadTool(workspace);
+    const ctx = createContext('s-missing');
+
+    const result = await tool.execute({}, ctx);
+    expect(result.ok).toBe(false);
+    expect(result.output).toContain('Missing path');
+    expect(getWorkspaceReadDedupCount('s-missing', '')).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Verification of items already shipped in v0.6.0 (smoke checks only)
+// -----------------------------------------------------------------------------
+
+describe('v0.6.0 — verifications (already shipped)', () => {
+  it('#93 scheduler.enabledToolsets is part of CronJobDefinition (per-job allowlist)', async () => {
+    const { createScheduledAgentJob } = await import('../packages/scheduler/src/index.js');
+    const job = createScheduledAgentJob({
+      id: 'job-1',
+      schedule: 'every:5m',
+      task: 'do work',
+      enabledToolsets: ['web.search'],
+    });
+    expect(job.enabledToolsets).toEqual(['web.search']);
+  });
+
+  it('#121/#122 InMemoryDreamStore caps long-term entries (defensive smoke)', async () => {
+    const { InMemoryDreamStore } = await import('../packages/memory/src/index.js');
+    const store = new InMemoryDreamStore();
+    // Add a small, bounded sample to confirm the cap path exists without
+    // burning runtime — the full bound test lives in dream-memory.test.ts.
+    for (let i = 0; i < 5; i++) {
+      await store.addLive(`s-${i}`, `summary-${i}`);
+      await store.consolidate();
+    }
+    const longTerm = await store.getLongTerm(50);
+    expect(longTerm.length).toBeLessThanOrEqual(500);
+    expect(longTerm.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up sweep on v0.6.0. Triaged the 89 issues that v0.6.0 left open and processed every non-breaking item with another **8-way parallel agent execution** round. Of the 89 open: ~40 were closed retroactively (work was actually shipped in v0.6.0 but commit-message close keywords didn't match the GH issue numbers exactly), **26 implemented in this release**, ~23 remain (breaking changes / architectural scope deferred to v0.7).

- **7 commits**, ~50 files changed, ~+5,500 / -340 lines
- **2,532 / 2,532 tests passing** (up from 2,421 — **111 new tests**)
- 6 new test files

## Issue coverage in this PR

| Severity | Closed |
|---|---|
| CRITICAL | #69 #78 #85 #115 #116 #128 |
| WARNING | #80 #81 #86 #88 #103 #109 #118 #119 #120 #123 #134 #148 #156 #157 #158 #159 |
| NIT | #124 #136 #151 |

## Cross-package contracts added

- `MemoryManager.shutdown(sessionId, messages)` + `MemoryProvider.onSessionEnd?(...)` — `@crowclaw/memory`
- `WsAuthRateLimiter` + `GatewayIdempotencyClaim` + `claim()/poisonAfterProgress()/isPoisoned()` — `@crowclaw/gateway`
- `McpClient.sessionIdleTtlMs` + idle lifecycle helpers — `@crowclaw/mcp`
- `McpJsonRpcStdioTransport` autoReconnect + backoff — `@crowclaw/mcp`
- `PluginManifestModelCatalog` + `seedManifestCacheFromPlugin` — `@crowclaw/providers`
- `AcpToolInfo` + optional `tools?:` callback — `@crowclaw/acp`
- `pruneDeadBridgeProcesses` + `GatewayDebouncer.flush()` — `@crowclaw/runtime-node`
- All `Plugin*` symbols now exported from `@crowclaw/core` (canonical) — `@crowclaw/plugins` becomes shim

## Verification

- `npm run typecheck` → clean
- `npm test` → 2,532 / 2,532 (8.92s)
- 111 new tests across 6 v0.6.1 test files

## Test plan

- [x] Pre-CI: typecheck + full vitest run locally
- [ ] CI: typecheck + test on PR
- [ ] Smoke test: shutdown a runtime mid-flight, verify wsManager / debouncer / interval cleanup
- [ ] Smoke test: trigger /ws auth rate limiter → backoff ban → unban
- [ ] Smoke test: gateway dedupe poisoning after a tool side-effect

See CHANGELOG.md (#0.6.1) for full per-issue narrative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)