### PR TITLE
fix(release): add repository field for npm provenance (v0.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to CrowClaw will be documented in this file.
 > Releases v0.2.0 through v0.3.4 were tracked in GitHub Releases. See
 > https://github.com/subinium/hermes-agent-typescript/releases for details.
 
+## [0.6.3] — 2026-04-28 — npm provenance unblock (repository field on every package)
+
+Patch on top of v0.6.2's publish-pipeline fix. The v0.6.2 publish workflow ran end-to-end but failed at every actual `npm publish` call with `E422 Unprocessable Entity — Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/subinium/CrowClaw" from provenance`. npm's provenance verification requires `repository.url` on the published package.json — none of the workspace packages had it.
+
+### Fixed
+- **`repository`, `homepage`, `bugs` fields added to all 20 package.json files** (root + 19 workspaces). `repository.directory` set per-workspace so the npm registry links to the correct subpath. This unblocks `--provenance` so v0.6.3 publishes both `crowclaw@0.6.3` and `@crowclaw/*@0.6.3` to npm.
+
 ## [0.6.2] — 2026-04-28 — npm publish unblock + workspace packages on registry
 
 Patch release that unblocks the broken publish pipeline (v0.6.0 and v0.6.1 GitHub releases were tagged but the `publish` workflow failed at the test step in CI, so neither version reached the npm registry — `crowclaw@0.5.0` had been the last published version on npm) and adds workspace-level publishing so library consumers can install `@crowclaw/*` packages independently.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowclaw",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "description": "A self-improving TypeScript agent framework that learns from every conversation.",
   "bin": {
@@ -37,5 +37,13 @@
     "typescript": "^6.0.2",
     "vitest": "^4.1.4",
     "wrangler": "^4.81.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/acp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,9 +17,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.2"
+    "@crowclaw/core": "0.6.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/acp"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,5 +18,14 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -19,5 +19,14 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/gateway",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -23,5 +23,14 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/gateway"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/learning/package.json
+++ b/packages/learning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/learning",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,6 +17,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.2"
+    "@crowclaw/core": "0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/learning"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/mcp-server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,9 +17,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.2"
+    "@crowclaw/core": "0.6.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/mcp-server"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/mcp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,9 +17,18 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/sandbox-executor": "0.6.2"
+    "@crowclaw/sandbox-executor": "0.6.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/mcp"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/memory",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,7 +17,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.2",
-    "@crowclaw/storage": "0.6.2"
+    "@crowclaw/core": "0.6.3",
+    "@crowclaw/storage": "0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/memory"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/plugins",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,6 +17,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.2"
+    "@crowclaw/core": "0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/plugins"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/providers",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,6 +17,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.2"
+    "@crowclaw/core": "0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/providers"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/runtime-cloudflare/package.json
+++ b/packages/runtime-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/runtime-cloudflare",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,18 +18,27 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.8.9",
-    "@crowclaw/core": "0.6.2",
-    "@crowclaw/memory": "0.6.2",
-    "@crowclaw/providers": "0.6.2",
-    "@crowclaw/sandbox-executor": "0.6.2",
-    "@crowclaw/shared": "0.6.2",
-    "@crowclaw/storage": "0.6.2",
-    "@crowclaw/tools": "0.6.2",
-    "@crowclaw/gateway": "0.6.2",
-    "@crowclaw/workspace": "0.6.2",
-    "@crowclaw/learning": "0.6.2",
-    "@crowclaw/mcp": "0.6.2",
-    "@crowclaw/scheduler": "0.6.2",
-    "@crowclaw/plugins": "0.6.2"
+    "@crowclaw/core": "0.6.3",
+    "@crowclaw/memory": "0.6.3",
+    "@crowclaw/providers": "0.6.3",
+    "@crowclaw/sandbox-executor": "0.6.3",
+    "@crowclaw/shared": "0.6.3",
+    "@crowclaw/storage": "0.6.3",
+    "@crowclaw/tools": "0.6.3",
+    "@crowclaw/gateway": "0.6.3",
+    "@crowclaw/workspace": "0.6.3",
+    "@crowclaw/learning": "0.6.3",
+    "@crowclaw/mcp": "0.6.3",
+    "@crowclaw/scheduler": "0.6.3",
+    "@crowclaw/plugins": "0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/runtime-cloudflare"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/runtime-node/package.json
+++ b/packages/runtime-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/runtime-node",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -33,18 +33,27 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/acp": "0.6.2",
-    "@crowclaw/core": "0.6.2",
-    "@crowclaw/gateway": "0.6.2",
-    "@crowclaw/learning": "0.6.2",
-    "@crowclaw/mcp": "0.6.2",
-    "@crowclaw/mcp-server": "0.6.2",
-    "@crowclaw/memory": "0.6.2",
-    "@crowclaw/plugins": "0.6.2",
-    "@crowclaw/providers": "0.6.2",
-    "@crowclaw/scheduler": "0.6.2",
-    "@crowclaw/storage": "0.6.2",
-    "@crowclaw/tools": "0.6.2",
-    "@crowclaw/workspace": "0.6.2"
+    "@crowclaw/acp": "0.6.3",
+    "@crowclaw/core": "0.6.3",
+    "@crowclaw/gateway": "0.6.3",
+    "@crowclaw/learning": "0.6.3",
+    "@crowclaw/mcp": "0.6.3",
+    "@crowclaw/mcp-server": "0.6.3",
+    "@crowclaw/memory": "0.6.3",
+    "@crowclaw/plugins": "0.6.3",
+    "@crowclaw/providers": "0.6.3",
+    "@crowclaw/scheduler": "0.6.3",
+    "@crowclaw/storage": "0.6.3",
+    "@crowclaw/tools": "0.6.3",
+    "@crowclaw/workspace": "0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/runtime-node"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/sandbox-executor/package.json
+++ b/packages/sandbox-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/sandbox-executor",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,7 +18,16 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.8.9",
-    "@crowclaw/core": "0.6.2",
-    "@crowclaw/tools": "0.6.2"
+    "@crowclaw/core": "0.6.3",
+    "@crowclaw/tools": "0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/sandbox-executor"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/scheduler",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,5 +18,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/scheduler"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/shared",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -15,5 +15,14 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/shared"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/storage",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,10 +17,19 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.2",
-    "@crowclaw/shared": "0.6.2"
+    "@crowclaw/core": "0.6.3",
+    "@crowclaw/shared": "0.6.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/storage"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/tools",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -17,12 +17,21 @@
     "access": "public"
   },
   "dependencies": {
-    "@crowclaw/core": "0.6.2",
-    "@crowclaw/gateway": "0.6.2",
-    "@crowclaw/memory": "0.6.2",
-    "@crowclaw/mcp": "0.6.2",
-    "@crowclaw/scheduler": "0.6.2",
-    "@crowclaw/storage": "0.6.2",
-    "@crowclaw/workspace": "0.6.2"
+    "@crowclaw/core": "0.6.3",
+    "@crowclaw/gateway": "0.6.3",
+    "@crowclaw/memory": "0.6.3",
+    "@crowclaw/mcp": "0.6.3",
+    "@crowclaw/scheduler": "0.6.3",
+    "@crowclaw/storage": "0.6.3",
+    "@crowclaw/workspace": "0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/tools"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/web",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -27,5 +27,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/web"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crowclaw/workspace",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "src/index.ts",
@@ -18,5 +18,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/subinium/CrowClaw.git",
+    "directory": "packages/workspace"
+  },
+  "homepage": "https://github.com/subinium/CrowClaw",
+  "bugs": {
+    "url": "https://github.com/subinium/CrowClaw/issues"
   }
 }


### PR DESCRIPTION
v0.6.2 publish workflow ran end-to-end but every `npm publish` failed with `E422 — repository.url is ""\, expected to match GitHub URL from provenance`. Added `repository`, `homepage`, `bugs` fields to all 20 package.jsons.

After merge + tag v0.6.3, the publish workflow should land both `crowclaw@0.6.3` and `@crowclaw/*@0.6.3` on npm.

Verified: `npm run preflight` 2,532 / 2,532.